### PR TITLE
Show correct app build date

### DIFF
--- a/common/src/jvmMain/kotlin/com/artemchep/keyguard/copy/GetAppBuildDateImpl.kt
+++ b/common/src/jvmMain/kotlin/com/artemchep/keyguard/copy/GetAppBuildDateImpl.kt
@@ -23,7 +23,6 @@ class GetAppBuildDateImpl(
             val dateFormat = SimpleDateFormat("yyyyMMdd")
             val date = dateFormat.parse(BuildKonfig.buildDate)!!
             Instant.fromEpochMilliseconds(date.time)
-            Clock.System.now()
         }
         val date = formatter.formatDate(instant)
         emit(date)


### PR DESCRIPTION
I noticed that in app settings, the preference "App build date" was equal to the same day, even there were no updates