### PR TITLE
fix: Ktor method not found

### DIFF
--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/api/login.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/api/login.kt
@@ -30,7 +30,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.Parameters
 import io.ktor.http.contentType
-import io.ktor.utils.io.InternalAPI
+import io.ktor.util.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,8 @@ ktlint = "0.50.0"
 # https://github.com/JLLeitschuh/ktlint-gradle
 ktlintPlugin = "12.0.3"
 # https://github.com/ktorio/ktor
-ktor = "3.0.0-beta-1"
+# Keep in sync with https://github.com/Kamel-Media/Kamel/blob/main/gradle/libs.versions.toml#L24
+ktor = "2.3.7"
 # https://github.com/skydoves/landscapist
 landscapist = "2.2.13"
 # https://github.com/cashapp/licensee


### PR DESCRIPTION
While testing, I encountered the following exception:

```
java.lang.NoSuchMethodError: 'void io.ktor.client.plugins.BodyProgressKt.onDownload(io.ktor.client.request.HttpRequestBuilder, kotlin.jvm.functions.Function3)'
	at io.kamel.core.fetcher.HttpFetcher$fetch$1.invokeSuspend(HttpFetcher.kt:33)
	at io.kamel.core.fetcher.HttpFetcher$fetch$1.invoke(HttpFetcher.kt)
	at io.kamel.core.fetcher.HttpFetcher$fetch$1.invoke(HttpFetcher.kt)
	at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo$suspendImpl(Builders.kt:320)
	at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo(Builders.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend(ChannelFlow.kt:60)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:115)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:103)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:806)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:710)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:697)
```

It seems like using Ktor `3.0.0-beta-1` instead of `2.3.7` causes this, as `Kamel-Media` uses `2.3.7`