### PR TITLE
fix: MaterialRichText3.kt has been renamed to RichText.kt

### DIFF
--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/ui/markdown/Markdown.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/ui/markdown/Markdown.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.ui.RichTextStyle
-import com.halilibo.richtext.ui.material3.Material3RichText
+import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 import com.halilibo.richtext.ui.string.RichTextStringStyle
 
@@ -21,7 +21,7 @@ fun MarkdownText(
             ),
         ),
     )
-    Material3RichText(
+    RichText(
         modifier = modifier,
         style = richTextStyle,
     ) {


### PR DESCRIPTION
`MaterialRichText3.kt` has been moved to `RichText.kt` ([commit](https://github.com/halilozercan/compose-richtext/commits/c2fd60ce2a7bb7a924834cf8d91105f577aff52b/richtext-ui-material3/src/commonMain/kotlin/com/halilibo/richtext/ui/material3/MaterialRichText3.kt?browsing_rename_history=true&new_path=richtext-ui-material3%2Fsrc%2FcommonMain%2Fkotlin%2Fcom%2Fhalilibo%2Frichtext%2Fui%2Fmaterial3%2FRichText.kt&original_branch=main))