### PR TITLE
Fix: Cannot upgrade on Windows

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -78,6 +78,12 @@ compose.desktop {
             }
             windows {
                 iconFile.set(project.file("icon.ico"))
+
+                // The UUID is used with `Windows Installer` to identify
+                // products, components, upgrades, and other key elements of the installation process.
+                // See:
+                // https://wixtoolset.org/docs/v3/howtos/general/generate_guids/
+                upgradeUuid = "846C6281-F349-4833-9E0E-AAE1C06006A0"
             }
             linux {
                 iconFile.set(project.file("icon.png"))


### PR DESCRIPTION
Set a fixed UUID in `desktopApp/build.gradle.kts`.

The UUID (`846C6281-F349-4833-9E0E-AAE1C06006A0`) is from MSI Installer of this release (https://github.com/AChep/keyguard-app/releases/tag/r20240503).

![image](https://github.com/AChep/keyguard-app/assets/69967436/b189a45f-b9a0-4645-a13c-171f037e0790)
