### PR TITLE
Update some deprecated workflow actions & command

### DIFF
--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -27,9 +27,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - name: "Check licenses"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:

--- a/.github/workflows/new_apk.yaml
+++ b/.github/workflows/new_apk.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - name: "Prepare env"
         run: |
           echo ${{ secrets.KEYSTORE_B64 }} | base64 -d | zcat >> androidApp/keyguard-release.keystore
@@ -26,7 +25,7 @@ jobs:
           echo "versionRef=$(git rev-parse --short HEAD)" >> gradle.properties
           echo buildkonfig.flavor=release >> gradle.properties
       - name: "Check and Build licenses"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -35,7 +34,7 @@ jobs:
         run: |
           mv -f androidApp/build/reports/licensee/androidNoneRelease/artifacts.json common/src/commonMain/resources/MR/files/licenses.json
       - name: "./gradlew :androidApp:assembleNoneRelease"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:

--- a/.github/workflows/new_daily_tag_play_store_internal_track.yaml
+++ b/.github/workflows/new_daily_tag_play_store_internal_track.yaml
@@ -16,10 +16,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Prepare env"
         run: |
           echo ${{ secrets.KEYSTORE_B64 }} | base64 -d | zcat >> androidApp/keyguard-release.keystore
@@ -31,7 +30,7 @@ jobs:
           echo "versionRef=$(git rev-parse --short HEAD)" >> gradle.properties
           echo buildkonfig.flavor=release >> gradle.properties
       - name: "Check and Build licenses"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -40,7 +39,7 @@ jobs:
         run: |
           mv -f androidApp/build/reports/licensee/androidPlayStoreRelease/artifacts.json common/src/commonMain/resources/MR/files/licenses.json
       - name: "Build release bundle"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:

--- a/.github/workflows/new_tag_release.yaml
+++ b/.github/workflows/new_tag_release.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - name: "Decode signing certificate"
         run: |
           echo ${{ secrets.CERT_B64 }} | base64 -d | zcat > desktopApp/macos-dev.cer
@@ -33,7 +32,7 @@ jobs:
           p12-password: ${{ secrets.CERT_PASSWD }}
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Setup build env"
         run: |
           echo "" >> gradle.properties
@@ -51,7 +50,7 @@ jobs:
           echo "notarization_password=${{ secrets.NOTARIZATION_PASSWD }}" >> gradle.properties
           echo "notarization_asc_provider=${{ secrets.NOTARIZATION_ASC_PROVIDER }}" >> gradle.properties
       - name: "./gradlew :desktopApp:packageDmg :desktopApp:notarizeDmg"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -94,10 +93,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Setup build env"
         run: |
           echo "" >> gradle.properties
@@ -105,7 +103,7 @@ jobs:
           echo "versionRef=$(git rev-parse --short HEAD)" >> gradle.properties
           echo buildkonfig.flavor=release >> gradle.properties
       - name: "./gradlew :desktopApp:bundleFlatpak"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -134,17 +132,16 @@ jobs:
           java-version: |
             11
             17
-          cache: 'gradle'
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Setup build env"
         run: |
           echo "" >> gradle.properties
           echo "versionRef=$(git rev-parse --short HEAD)" >> gradle.properties
           echo buildkonfig.flavor=release >> gradle.properties
       - name: "./gradlew :desktopApp:packageMsi"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -167,10 +164,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Prepare env"
         run: |
           echo ${{ secrets.KEYSTORE_B64 }} | base64 -d | zcat >> androidApp/keyguard-release.keystore
@@ -180,7 +176,7 @@ jobs:
           echo "versionRef=$(git rev-parse --short HEAD)" >> gradle.properties
           echo buildkonfig.flavor=release >> gradle.properties
       - name: "Check and Build licenses"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -189,7 +185,7 @@ jobs:
         run: |
           mv -f androidApp/build/reports/licensee/androidNoneRelease/artifacts.json common/src/commonMain/resources/MR/files/licenses.json
       - name: "./gradlew :androidApp:assembleNoneRelease"
-        uses: eskatos/gradle-command-action@v3
+        uses: gradle/actions/setup-gradle@v3
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -243,7 +239,7 @@ jobs:
           path: artifacts
       - id: vars
         run: |
-          echo ::set-output name=tag::${GITHUB_REF:11}
+          echo name=tag::${GITHUB_REF:11} >> $GITHUB_OUTPUT
       - name: "Create release"
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Changes
- Update command `set-output` (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. It will be disabled soon)
- Update `action` (https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)
- Remove `cache: 'gradle'` (https://github.com/gradle/actions/blob/v3/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms)