### PR TITLE
fix: allow `Fido2Credentials.rpName` with `null` value

### DIFF
--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/AddPasskeyCipherRequest.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/AddPasskeyCipherRequest.kt
@@ -11,7 +11,7 @@ data class AddPasskeyCipherRequest(
         val keyCurve: String, // P-256
         val keyValue: String,
         val rpId: String,
-        val rpName: String,
+        val rpName: String?,
         val counter: Int?,
         val userHandle: String,
         val userName: String?,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/DSecret.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/DSecret.kt
@@ -323,7 +323,7 @@ data class DSecret(
             val keyCurve: String, // P-256
             val keyValue: String,
             val rpId: String,
-            val rpName: String,
+            val rpName: String?,
             val counter: Int?,
             val userHandle: String,
             val userName: String?,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/service/export/entity/ItemLoginExportEntity.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/service/export/entity/ItemLoginExportEntity.kt
@@ -28,7 +28,7 @@ data class ItemLoginFido2CredentialsExportEntity(
     val keyCurve: String,
     val keyValue: String,
     val rpId: String,
-    val rpName: String,
+    val rpName: String?,
     val counter: String,
     val userHandle: String,
     val userName: String? = null,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/core/store/bitwarden/BitwardenCipher.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/core/store/bitwarden/BitwardenCipher.kt
@@ -232,7 +232,7 @@ data class BitwardenCipher(
             val keyCurve: String,
             val keyValue: String,
             val rpId: String,
-            val rpName: String,
+            val rpName: String?,
             val counter: String,
             val userHandle: String,
             val userName: String? = null,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/add/AddScreen.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/add/AddScreen.kt
@@ -762,7 +762,7 @@ private fun PasskeyField(
                     },
                     text = {
                         Text(
-                            text = passkey.rpName,
+                            text = passkey.rpName ?: "",
                         )
                     },
                 )

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/add/AddStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/add/AddStateProducer.kt
@@ -1147,7 +1147,7 @@ class AddStateItemPasskeyFactory(
         val keyCurve: String, // P-256
         val keyValue: String,
         val rpId: String,
-        val rpName: String,
+        val rpName: String?,
         val counter: Int?,
         val userHandle: String,
         val userName: String? = null,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/passkeys/PasskeysCredentialViewScreen.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/passkeys/PasskeysCredentialViewScreen.kt
@@ -211,7 +211,7 @@ private fun ColumnScope.ContentOk(
                     val rpId = state.model.rpId
                     Column {
                         Text(
-                            text = rpName,
+                            text = rpName ?: "",
                         )
                         Text(
                             text = rpId,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/LoginFido2CredentialsEntity.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/LoginFido2CredentialsEntity.kt
@@ -27,7 +27,7 @@ data class LoginFido2CredentialsEntity(
     val rpId: String,
     @JsonNames("rpName")
     @SerialName("RpName")
-    val rpName: String,
+    val rpName: String?,
     @JsonNames("counter")
     @SerialName("Counter")
     val counter: String,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/api/LoginFido2CredentialsRequest.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/api/LoginFido2CredentialsRequest.kt
@@ -20,7 +20,7 @@ data class LoginFido2CredentialsRequest(
     @SerialName("rpId")
     val rpId: String,
     @SerialName("rpName")
-    val rpName: String,
+    val rpName: String?,
     @SerialName("counter")
     val counter: String,
     @SerialName("userHandle")


### PR DESCRIPTION
Fixes #350

Confirmed sync succeeds and error message does not appear  with debug build