### PR TITLE
Added compatibility to macOS on arm64 architecture

### DIFF
--- a/.github/workflows/new_tag_release.yaml
+++ b/.github/workflows/new_tag_release.yaml
@@ -63,6 +63,10 @@ jobs:
           name: binaries-mac
           path: desktopApp/build/compose/binaries/main/**
           retention-days: 1
+      - name: "Add a suffix to the artifacts"
+        run: |
+          cd desktopApp/build/compose/binaries/main/dmg
+          for f in * ; do mv -- "$f" "$(echo $f | sed -nE 's/^(.*)(\..*)$/\1-arm64\2/p')" ; done
       - name: "Upload .dmg"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/new_tag_release.yaml
+++ b/.github/workflows/new_tag_release.yaml
@@ -6,7 +6,70 @@ on:
       - 'r*'
 
 jobs:
-  build-macos-app:
+  build-macos-silicon-app:
+    runs-on: macos-14
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+      - name: "Set up JDK 17"
+        id: setup-java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "liberica"
+          java-version: "17"
+          architecture: arm64
+      - name: "Decode signing certificate"
+        run: |
+          echo ${{ secrets.CERT_B64 }} | base64 -d | zcat > desktopApp/macos-dev.cer
+      - name: "Import signing certificate"
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-filepath: desktopApp/macos-dev.cer
+          p12-password: ${{ secrets.CERT_PASSWD }}
+      - name: "Setup build env"
+        run: |
+          python .github/setup_gradle_properties_release.py tag=${{ github.ref_name }}
+      - name: "Setup signing config"
+        run: |
+          echo "" >> gradle.properties
+          echo "cert_identity=${{ secrets.CERT_IDENTITY }}" >> gradle.properties
+      - name: "Setup notarization config"
+        run: |
+          echo "" >> gradle.properties
+          echo "notarization_apple_id=${{ secrets.NOTARIZATION_APPLE_ID }}" >> gradle.properties
+          echo "notarization_password=${{ secrets.NOTARIZATION_PASSWD }}" >> gradle.properties
+          echo "notarization_asc_provider=${{ secrets.NOTARIZATION_ASC_PROVIDER }}" >> gradle.properties
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+      - name: "Build"
+        run: ./gradlew :desktopApp:packageDmg :desktopApp:notarizeDmg
+      - name: "Upload logs"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs-mac
+          path: desktopApp/build/compose/logs/**/*.txt
+          retention-days: 30
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-mac
+          path: desktopApp/build/compose/binaries/main/**
+          retention-days: 1
+      - name: "Upload .dmg"
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-mac-silicon
+          path: desktopApp/build/compose/binaries/main/dmg/*.dmg
+          retention-days: 1
+  build-macos-intel-app:
     runs-on: macos-12
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +128,7 @@ jobs:
       - name: 'Upload .dmg'
         uses: actions/upload-artifact@v4
         with:
-          name: app-mac
+          name: app-mac-intel
           path: desktopApp/build/compose/binaries/main/dmg/*.dmg
           retention-days: 1
   build-linux-flatpak-app:
@@ -183,7 +246,8 @@ jobs:
     needs:
       - build-android-app
       - build-linux-flatpak-app
-      - build-macos-app
+      - build-macos-silicon-app
+      - build-macos-intel-app
       - build-windows-app
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -197,10 +261,15 @@ jobs:
         uses: metcalfc/changelog-generator@v4.3.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Download Mac app"
+      - name: "Download Mac app (Intel)"
         uses: actions/download-artifact@v4
         with:
-          name: app-mac
+          name: app-mac-intel
+          path: artifacts
+      - name: "Download Mac app (Apple Silicon)"
+        uses: actions/download-artifact@v4
+        with:
+          name: app-mac-silicon
           path: artifacts
       - name: "Download Linux app"
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Implemented the Github action workflow to build two versions of the application for macOS:
 - Apple Silicon (arm64) using Liberica JDK 17
 - Apple Intel (x64) using Temurin JDK 17

Closes #606 