### PR TITLE
New Public suffix list by GitHub Action

### DIFF
--- a/common/src/commonMain/composeResources/files/public_suffix_list.txt
+++ b/common/src/commonMain/composeResources/files/public_suffix_list.txt
@@ -5,8 +5,8 @@
 // Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
 // rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
 
-// VERSION: 2025-01-25_15-41-12_UTC
-// COMMIT: 2aa65d89a1b96b0065ad5970734200eed5a38713
+// VERSION: 2025-01-31_07-02-21_UTC
+// COMMIT: 5421ee732b6ad9733220267cd8d3d6b45a63ce05
 
 // Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
@@ -12309,6 +12309,9 @@ square7.net
 
 // Brave : https://brave.com
 // Submitted by Andrea Brancaleoni <abrancaleoni@brave.com>
+brave.app
+*.s.brave.app
+brave.io
 *.s.brave.io
 
 // Brendly : https://brendly.rs
@@ -14062,6 +14065,11 @@ ggff.net
 localcert.net
 localhostcert.net
 
+// Localtonet : https://localtonet.com/
+// Submitted by Burak Isleyici <support@localtonet.com>
+localtonet.com
+*.localto.net
+
 // Lodz University of Technology LODMAN regional domains : https://www.man.lodz.pl/dns
 // Submitted by Piotr Wilk <dns@man.lodz.pl>
 lodz.pl
@@ -15478,6 +15486,10 @@ unison-services.cloud
 // Submitted by Stefan Schwarz <sysadm@united-gameserver.de>
 virtual-user.de
 virtualuser.de
+
+// United States Writing Corporation : https://uswriting.co
+// Submitted by Andrew Sampson <security@obj.ag>
+obj.ag
 
 // UNIVERSAL DOMAIN REGISTRY : https://www.udr.org.yt/
 // see also: whois -h whois.udr.org.yt help


### PR DESCRIPTION
* 937a33c6 - dependabot[bot] - 2025-02-05 01:07:05 
  build(deps): Bump com.yubico.yubikit:android from 2.7.0 to 2.8.0
  Bumps [com.yubico.yubikit:android](https://github.com/Yubico/yubikit-android) from 2.7.0 to 2.8.0.
  - [Release notes](https://github.com/Yubico/yubikit-android/releases)
  - [Changelog](https://github.com/Yubico/yubikit-android/blob/main/NEWS)
  - [Commits](https://github.com/Yubico/yubikit-android/compare/2.7.0...2.8.0)
  
  ---
  updated-dependencies:
  - dependency-name: com.yubico.yubikit:android
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>
* eca70099 - AChep - 2025-02-04 23:07:05 
  [AUTO]Update Public suffix list
  Files changed:
  M	common/src/commonMain/composeResources/files/public_suffix_list.txt