### PR TITLE
fix fcitx5-android autfill count

### DIFF
--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/autofill/KeyguardAutofillService.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/autofill/KeyguardAutofillService.kt
@@ -693,6 +693,9 @@ class KeyguardAutofillService : AutofillService(), DIAware {
         val spec = request.inlineSuggestionsRequest
             ?.inlinePresentationSpecs
             ?.getOrNull(index)
+            ?: request.inlineSuggestionsRequest
+                ?.inlinePresentationSpecs
+                ?.getOrNull(0) 
             ?: return null
         val imeStyle = spec.style
         if (UiVersions.getVersions(imeStyle).contains(UiVersions.INLINE_UI_VERSION_1)) {


### PR DESCRIPTION
fcitx5-android
https://github.com/fcitx5-android/fcitx5-android/blob/ee94b83e2bae29e60382f868a96503686b42c65f/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt#L943
``` kotlin
return InlineSuggestionsRequest.Builder(listOf(spec))
     .setMaxSuggestionCount(InlineSuggestionsRequest.SUGGESTION_COUNT_UNLIMITED)
            .build()

```
当 InlineSuggestionsRequest.Builder(@NonNull List<InlinePresentationSpec> inlinePresentationSpecs) inlinePresentationSpecs.size = 1

https://github.com/sunO2/keyguard-app/blob/97390ff9e70b7cc027cc8fadc58531736ec2d195/common/src/androidMain/kotlin/com/artemchep/keyguard/android/autofill/KeyguardAutofillService.kt#L693

```
request.inlineSuggestionsRequest
            ?.inlinePresentationSpecs
            ?.getOrNull(index)
            ?: return null
```
数据存在多条的话  index > 1  return null 只显示一条