### PR TITLE
Add support for IronFox Nightly

### DIFF
--- a/.github/update_gpm_passkeys_priv_apps.py
+++ b/.github/update_gpm_passkeys_priv_apps.py
@@ -56,6 +56,20 @@ EXTRA_APPS = [
             ]
         }
     },
+    # IronFox Nightly
+    # https://gitlab.com/ironfox-oss/IronFox
+    {
+        "type": "android",
+        "info": {
+            "package_name": "org.ironfoxoss.ironfox.nightly",
+            "signatures": [
+                {
+                    "build": "release",
+                    "cert_fingerprint_sha256": "C5:E2:91:B5:A5:71:F9:C8:CD:9A:97:99:C2:C9:4E:02:EC:97:03:94:88:93:F2:CA:75:6D:67:B9:42:04:F9:04"
+                }
+            ]
+        }
+    },
     # Fennec F-Droid
     # https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/
     {


### PR DESCRIPTION
As of https://github.com/ironfox-oss/IronFox/commit/a2c7570bdc4dc824ec3b66f4ec12f9678cbe7de9, we're now using a separate package ID for Nightly builds.

Similar to https://github.com/AChep/keyguard-app/commit/5a9352b11a42f48c936fbf7bde5c0f8b2b490994, this adds support for IronFox Nightly.