### PR TITLE
Add vivo FIDO client (com.fido.client) to privileged apps

### DIFF
--- a/.github/update_gpm_passkeys_priv_apps.py
+++ b/.github/update_gpm_passkeys_priv_apps.py
@@ -116,6 +116,18 @@ EXTRA_APPS = [
             ]
         }
     },
+    {
+        "type": "android",
+        "info": {
+            "package_name": "com.fido.client",
+            "signatures": [
+                {
+                    "build": "release",
+                    "cert_fingerprint_sha256": "BC:C3:5D:4D:36:06:F1:54:F0:40:2A:B7:63:4E:84:90:C0:B2:44:C2:67:5C:3C:62:38:98:69:87:02:4F:0C:02"
+                }
+            ]
+        }
+    },
 ]
 
 response = requests.get(

--- a/common/src/commonMain/composeResources/files/gpm_passkeys_privileged_apps.json
+++ b/common/src/commonMain/composeResources/files/gpm_passkeys_privileged_apps.json
@@ -891,6 +891,18 @@
           }
         ]
       }
+    },
+    {
+      "type": "android",
+      "info": {
+        "package_name": "com.fido.client",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "BC:C3:5D:4D:36:06:F1:54:F0:40:2A:B7:63:4E:84:90:C0:B2:44:C2:67:5C:3C:62:38:98:69:87:02:4F:0C:02"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds the preinstalled vivo FIDO / passkey client `com.fido.client` to the privileged apps list consumed by Keyguard (via `.github/update_gpm_passkeys_priv_apps.py`).

On recent vivo devices (OriginOS / Android 14), passkey flows routed through the system FIDO UI (`com.fido.client`) can fail in passkey providers with errors like:

> The calling app 'com.fido.client' is not on the privileged list and cannot request authentication on behalf of the other app.

By trusting `com.fido.client` (package name + SHA-256 cert fingerprint), Keyguard can successfully complete passkey registration and authentication when the vivo system FIDO UI mediates the request. This change is aligned with a similar community contribution to Bitwarden:
https://github.com/bitwarden/android/pull/6114

Verification:
- Set Keyguard as the default passkey provider on a vivo device.
- Use https://passkeys.io / https://webauthn.io with QR / cross-device sign-in.
- Confirm that passkey registration and authentication via `com.fido.client` succeed after this change.

![Screenshot_20251103_233149](https://github.com/user-attachments/assets/7d4dc3d3-b816-467f-9f26-63ffd9db3e96)
![Screenshot_20251103_233134](https://github.com/user-attachments/assets/8d73caa2-a691-46c1-a68c-1843a90e4af4)
