### PR TITLE
feat: add WebAuthn PRF extension support

### DIFF
--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
@@ -229,6 +229,26 @@ class PasskeyCreateRequest(
                 if (data.extensions?.prf != null) {
                     put("prf", buildJsonObject {
                         put("enabled", true)
+                        // CTAP 2.2+: if the RP provided eval inputs at creation time,
+                        // return the PRF results immediately so they don't need a
+                        // separate authentication round-trip.
+                        val eval = data.extensions.prf.eval
+                        if (eval != null) {
+                            put("results", buildJsonObject {
+                                val firstOutput = passkeyUtils.computePrf(
+                                    privateKeyBytes = keyPair.private.encoded,
+                                    prfInput = PasskeyBase64.decode(eval.first),
+                                )
+                                put("first", PasskeyBase64.encodeToString(firstOutput))
+                                eval.second?.let { secondBase64 ->
+                                    val secondOutput = passkeyUtils.computePrf(
+                                        privateKeyBytes = keyPair.private.encoded,
+                                        prfInput = PasskeyBase64.decode(secondBase64),
+                                    )
+                                    put("second", PasskeyBase64.encodeToString(secondOutput))
+                                }
+                            })
+                        }
                     })
                 }
             })

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
@@ -179,6 +179,11 @@ class PasskeyCreateRequest(
         )
 
         val keyValue = base64Service.encodeToString(keyPair.private.encoded)
+        // Generate a fresh 32-byte PRF secret (the "credRandom" equivalent).
+        // This is stored alongside the credential and used as the HMAC key for all
+        // future PRF evaluations — it is never derived from the signing key.
+        val prfSecretBytes = passkeyUtils.generatePrfSecret()
+        val prfSecret = base64Service.encodeToString(prfSecretBytes)
         val discoverable = data.authenticatorSelection.requireResidentKey ||
                 data.authenticatorSelection.residentKey == "required" ||
                 data.authenticatorSelection.residentKey == "preferred"
@@ -188,6 +193,7 @@ class PasskeyCreateRequest(
             keyAlgorithm = "ECDSA",
             keyCurve = "P-256",
             keyValue = keyValue,
+            prfSecret = prfSecret,
             rpId = rpId,
             rpName = rpName,
             counter = 0,
@@ -229,20 +235,20 @@ class PasskeyCreateRequest(
                 if (data.extensions?.prf != null) {
                     put("prf", buildJsonObject {
                         put("enabled", true)
-                        // CTAP 2.2+: if the RP provided eval inputs at creation time,
-                        // return the PRF results immediately so they don't need a
-                        // separate authentication round-trip.
+                        // CTAP 2.2+: if the RP provided eval inputs at creation time and
+                        // user was verified, return the PRF results immediately so the RP
+                        // doesn't need a separate authentication round-trip.
                         val eval = data.extensions.prf.eval
-                        if (eval != null) {
+                        if (eval != null && userVerified) {
                             put("results", buildJsonObject {
                                 val firstOutput = passkeyUtils.computePrf(
-                                    privateKeyBytes = keyPair.private.encoded,
+                                    prfSecretBytes = prfSecretBytes,
                                     prfInput = PasskeyBase64.decode(eval.first),
                                 )
                                 put("first", PasskeyBase64.encodeToString(firstOutput))
                                 eval.second?.let { secondBase64 ->
                                     val secondOutput = passkeyUtils.computePrf(
-                                        privateKeyBytes = keyPair.private.encoded,
+                                        prfSecretBytes = prfSecretBytes,
                                         prfInput = PasskeyBase64.decode(secondBase64),
                                     )
                                     put("second", PasskeyBase64.encodeToString(secondOutput))

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyCreateRequest.kt
@@ -225,7 +225,13 @@ class PasskeyCreateRequest(
                     put("authenticatorData", authData)
                 },
             )
-            put("clientExtensionResults", buildJsonObject { })
+            put("clientExtensionResults", buildJsonObject {
+                if (data.extensions?.prf != null) {
+                    put("prf", buildJsonObject {
+                        put("enabled", true)
+                    })
+                }
+            })
         }
         val registrationResponseJson = json.encodeToString(registrationResponse)
         return CreatePublicKeyCredentialResponse(registrationResponseJson) to local

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyProviderGetRequest.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyProviderGetRequest.kt
@@ -124,23 +124,33 @@ class PasskeyProviderGetRequest(
             put("signature", PasskeyBase64.encodeToString(signature))
             put("userHandle", credential.userHandle)
         }
-        val prfResults = resolvePrfEvalInput(opt.requestJson, credentialIdBytes)
-            ?.let { eval ->
-                buildJsonObject {
-                    val firstOutput = passkeyUtils.computePrf(
-                        privateKeyBytes = privateKeyBytes,
-                        prfInput = PasskeyBase64.decode(eval.first),
+        val prfEvalInput = resolvePrfEvalInput(opt.requestJson, credentialIdBytes)
+        // Decode the stored PRF secret (the "credRandom" equivalent) for this credential.
+        // Only compute PRF results when the user was verified — PRF output must be
+        // bound to a verified user identity to be meaningful for encryption use cases.
+        val prfSecretBytes = if (userVerified) {
+            credential.prfSecret?.let { base64Service.decode(it) }
+        } else {
+            null
+        }
+        val prfResults = if (prfEvalInput != null && prfSecretBytes != null) {
+            buildJsonObject {
+                val firstOutput = passkeyUtils.computePrf(
+                    prfSecretBytes = prfSecretBytes,
+                    prfInput = PasskeyBase64.decode(prfEvalInput.first),
+                )
+                put("first", PasskeyBase64.encodeToString(firstOutput))
+                prfEvalInput.second?.let { secondBase64 ->
+                    val secondOutput = passkeyUtils.computePrf(
+                        prfSecretBytes = prfSecretBytes,
+                        prfInput = PasskeyBase64.decode(secondBase64),
                     )
-                    put("first", PasskeyBase64.encodeToString(firstOutput))
-                    eval.second?.let { secondBase64 ->
-                        val secondOutput = passkeyUtils.computePrf(
-                            privateKeyBytes = privateKeyBytes,
-                            prfInput = PasskeyBase64.decode(secondBase64),
-                        )
-                        put("second", PasskeyBase64.encodeToString(secondOutput))
-                    }
+                    put("second", PasskeyBase64.encodeToString(secondOutput))
                 }
             }
+        } else {
+            null
+        }
         val authenticationResponse = buildJsonObject {
             put("id", PasskeyBase64.encodeToString(credentialIdBytes))
             put("rawId", credentialIdBytes)
@@ -148,9 +158,13 @@ class PasskeyProviderGetRequest(
             put("authenticatorAttachment", "cross-platform")
             put("response", r)
             put("clientExtensionResults", buildJsonObject {
-                if (prfResults != null) {
+                // Always include prf in clientExtensionResults when PRF was requested,
+                // even if we cannot produce results (spec: return prf: {} in that case).
+                if (prfEvalInput != null) {
                     put("prf", buildJsonObject {
-                        put("results", prfResults)
+                        if (prfResults != null) {
+                            put("results", prfResults)
+                        }
                     })
                 }
             })

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyProviderGetRequest.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyProviderGetRequest.kt
@@ -14,6 +14,7 @@ import com.artemchep.keyguard.common.model.DPrivilegedApp
 import com.artemchep.keyguard.common.model.DSecret
 import com.artemchep.keyguard.common.service.crypto.CryptoGenerator
 import com.artemchep.keyguard.common.service.text.Base64Service
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonObject
@@ -68,9 +69,9 @@ class PasskeyProviderGetRequest(
         val credentialIdBytes = PasskeyCredentialId.encode(credential.credentialId)
 
         val factory: KeyFactory = KeyFactory.getInstance("EC")
+        val privateKeyBytes = base64Service.decode(credential.keyValue)
         val privateKey = run {
-            val privateKeyData = base64Service.decode(credential.keyValue)
-            val privateKeySpec = PKCS8EncodedKeySpec(privateKeyData)
+            val privateKeySpec = PKCS8EncodedKeySpec(privateKeyBytes)
             factory.generatePrivate(privateKeySpec)
         }
 
@@ -123,20 +124,78 @@ class PasskeyProviderGetRequest(
             put("signature", PasskeyBase64.encodeToString(signature))
             put("userHandle", credential.userHandle)
         }
+        val prfResults = resolvePrfEvalInput(opt.requestJson, credentialIdBytes)
+            ?.let { eval ->
+                buildJsonObject {
+                    val firstOutput = passkeyUtils.computePrf(
+                        privateKeyBytes = privateKeyBytes,
+                        prfInput = PasskeyBase64.decode(eval.first),
+                    )
+                    put("first", PasskeyBase64.encodeToString(firstOutput))
+                    eval.second?.let { secondBase64 ->
+                        val secondOutput = passkeyUtils.computePrf(
+                            privateKeyBytes = privateKeyBytes,
+                            prfInput = PasskeyBase64.decode(secondBase64),
+                        )
+                        put("second", PasskeyBase64.encodeToString(secondOutput))
+                    }
+                }
+            }
         val authenticationResponse = buildJsonObject {
             put("id", PasskeyBase64.encodeToString(credentialIdBytes))
             put("rawId", credentialIdBytes)
             put("type", "public-key")
             put("authenticatorAttachment", "cross-platform")
             put("response", r)
-            put("clientExtensionResults", buildJsonObject { })
+            put("clientExtensionResults", buildJsonObject {
+                if (prfResults != null) {
+                    put("prf", buildJsonObject {
+                        put("results", prfResults)
+                    })
+                }
+            })
         }
         val authenticationResponseJson = json.encodeToString(authenticationResponse)
         val passkeyCredential = PublicKeyCredential(authenticationResponseJson)
         return GetCredentialResponse(passkeyCredential)
     }
 
+    private fun resolvePrfEvalInput(
+        requestJson: String,
+        credentialIdBytes: ByteArray,
+    ): PrfEvalInput? {
+        val options = runCatching {
+            json.decodeFromString<GetCredentialRequestOptions>(requestJson)
+        }.getOrNull()
+        val prf = options?.extensions?.prf ?: return null
+        val credentialIdBase64 = PasskeyBase64.encodeToString(credentialIdBytes)
+        return prf.evalByCredential[credentialIdBase64] ?: prf.eval
+    }
+
     private fun JsonObjectBuilder.put(key: String, data: ByteArray) {
         put(key, PasskeyBase64.encodeToString(data))
     }
+
+    // https://www.w3.org/TR/webauthn-3/#prf-extension
+    @Serializable
+    private data class GetCredentialRequestOptions(
+        val extensions: GetCredentialExtensions? = null,
+    )
+
+    @Serializable
+    private data class GetCredentialExtensions(
+        val prf: GetCredentialPrfExtension? = null,
+    )
+
+    @Serializable
+    private data class GetCredentialPrfExtension(
+        val eval: PrfEvalInput? = null,
+        val evalByCredential: Map<String, PrfEvalInput> = emptyMap(),
+    )
+
+    @Serializable
+    private data class PrfEvalInput(
+        val first: String,
+        val second: String? = null,
+    )
 }

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyUtils.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyUtils.kt
@@ -50,6 +50,10 @@ class PasskeyUtils(
          */
         private const val PASSKEY_PROCESSING_MIN_TIME_MS = 800L
 
+        // https://www.w3.org/TR/webauthn-3/#prf-extension
+        // "WebAuthn PRF" followed by a null byte, as required by the spec.
+        internal val PRF_LABEL = "WebAuthn PRF\u0000".toByteArray(Charsets.UTF_8)
+
         suspend fun <T> withProcessingMinTime(
             block: suspend () -> T,
         ): T = coroutineScope {
@@ -406,6 +410,18 @@ class PasskeyUtils(
 
     fun generateCredentialId() = cryptoService.uuid()
 
+    /**
+     * Computes the WebAuthn PRF output for the given private key bytes and PRF input.
+     *
+     * prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
+     * hmacKey   = HMAC-SHA-256(privateKeyBytes, "prf")
+     * prfOutput = HMAC-SHA-256(hmacKey, prfSalt)
+     */
+    fun computePrf(
+        privateKeyBytes: ByteArray,
+        prfInput: ByteArray,
+    ): ByteArray = computeWebAuthnPrf(cryptoService, privateKeyBytes, prfInput)
+
     // See:
     // https://github.com/1Password/passkey-rs/blob/90c1c282649eceeb7cbe771bb8ce17b1b8463c60/passkey-client/src/lib.rs#L407
     // https://github.com/kanidm/webauthn-rs/blame/25bc74ac0dc4280bf67ed3ff53fdf804dbb142c2/webauthn-rs-core/src/core.rs#L866
@@ -548,4 +564,27 @@ class PasskeyUtils(
             .bind()
         return appInfo.getOrigin(privilegedAllowlist)
     }
+}
+
+/**
+ * Standalone PRF computation, extracted for testability.
+ *
+ * prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
+ * hmacKey   = HMAC-SHA-256(privateKeyBytes, "prf")
+ * prfOutput = HMAC-SHA-256(hmacKey, prfSalt)
+ */
+internal fun computeWebAuthnPrf(
+    cryptoService: CryptoGenerator,
+    privateKeyBytes: ByteArray,
+    prfInput: ByteArray,
+): ByteArray {
+    val prfSalt = cryptoService.hashSha256(PasskeyUtils.PRF_LABEL + prfInput)
+    val hmacKey = cryptoService.hmacSha256(
+        key = privateKeyBytes,
+        data = "prf".toByteArray(Charsets.UTF_8),
+    )
+    return cryptoService.hmacSha256(
+        key = hmacKey,
+        data = prfSalt,
+    )
 }

--- a/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyUtils.kt
+++ b/common/src/androidMain/kotlin/com/artemchep/keyguard/android/PasskeyUtils.kt
@@ -410,17 +410,19 @@ class PasskeyUtils(
 
     fun generateCredentialId() = cryptoService.uuid()
 
+    /** Generates a fresh 32-byte random secret to use as the PRF key for a new credential. */
+    fun generatePrfSecret(): ByteArray = cryptoService.seed(32)
+
     /**
-     * Computes the WebAuthn PRF output for the given private key bytes and PRF input.
+     * Computes the WebAuthn PRF output for the given PRF secret and input.
      *
      * prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
-     * hmacKey   = HMAC-SHA-256(privateKeyBytes, "prf")
-     * prfOutput = HMAC-SHA-256(hmacKey, prfSalt)
+     * prfOutput = HMAC-SHA-256(prfSecretBytes, prfSalt)
      */
     fun computePrf(
-        privateKeyBytes: ByteArray,
+        prfSecretBytes: ByteArray,
         prfInput: ByteArray,
-    ): ByteArray = computeWebAuthnPrf(cryptoService, privateKeyBytes, prfInput)
+    ): ByteArray = computeWebAuthnPrf(cryptoService, prfSecretBytes, prfInput)
 
     // See:
     // https://github.com/1Password/passkey-rs/blob/90c1c282649eceeb7cbe771bb8ce17b1b8463c60/passkey-client/src/lib.rs#L407
@@ -569,22 +571,23 @@ class PasskeyUtils(
 /**
  * Standalone PRF computation, extracted for testability.
  *
- * prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
- * hmacKey   = HMAC-SHA-256(privateKeyBytes, "prf")
- * prfOutput = HMAC-SHA-256(hmacKey, prfSalt)
+ * Implements the WebAuthn PRF extension computation as a software authenticator.
+ * This mirrors what a hardware authenticator does with its internal credRandom key:
+ *
+ *   prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
+ *   prfOutput = HMAC-SHA-256(prfSecretBytes, prfSalt)
+ *
+ * The [prfSecretBytes] parameter is the "credRandom" equivalent — a 32-byte random
+ * secret generated at credential creation time and stored alongside the credential.
  */
 internal fun computeWebAuthnPrf(
     cryptoService: CryptoGenerator,
-    privateKeyBytes: ByteArray,
+    prfSecretBytes: ByteArray,
     prfInput: ByteArray,
 ): ByteArray {
     val prfSalt = cryptoService.hashSha256(PasskeyUtils.PRF_LABEL + prfInput)
-    val hmacKey = cryptoService.hmacSha256(
-        key = privateKeyBytes,
-        data = "prf".toByteArray(Charsets.UTF_8),
-    )
     return cryptoService.hmacSha256(
-        key = hmacKey,
+        key = prfSecretBytes,
         data = prfSalt,
     )
 }

--- a/common/src/androidUnitTest/kotlin/com/artemchep/keyguard/android/PasskeyPrfTest.kt
+++ b/common/src/androidUnitTest/kotlin/com/artemchep/keyguard/android/PasskeyPrfTest.kt
@@ -1,0 +1,118 @@
+package com.artemchep.keyguard.android
+
+import com.artemchep.keyguard.common.model.Argon2Mode
+import com.artemchep.keyguard.common.model.CryptoHashAlgorithm
+import com.artemchep.keyguard.common.service.crypto.CryptoGenerator
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class PasskeyPrfTest {
+    private val cryptoGenerator = JvmCryptoGenerator()
+
+    @Test
+    fun `computeWebAuthnPrf returns 32 bytes`() {
+        val output = computeWebAuthnPrf(
+            cryptoGenerator,
+            privateKeyBytes = "private-key".toByteArray(),
+            prfInput = "prf-input".toByteArray(),
+        )
+        org.junit.Assert.assertEquals(32, output.size)
+    }
+
+    @Test
+    fun `computeWebAuthnPrf is deterministic for the same inputs`() {
+        val privateKeyBytes = "private-key".toByteArray()
+        val prfInput = "prf-input".toByteArray()
+        val output1 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
+        val output2 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
+        assertArrayEquals(output1, output2)
+    }
+
+    @Test
+    fun `computeWebAuthnPrf different inputs produce different outputs`() {
+        val privateKeyBytes = "private-key".toByteArray()
+        val output1 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, "input-a".toByteArray())
+        val output2 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, "input-b".toByteArray())
+        assertFalse(output1.contentEquals(output2))
+    }
+
+    @Test
+    fun `computeWebAuthnPrf different keys produce different outputs`() {
+        val prfInput = "prf-input".toByteArray()
+        val output1 = computeWebAuthnPrf(cryptoGenerator, "key-1".toByteArray(), prfInput)
+        val output2 = computeWebAuthnPrf(cryptoGenerator, "key-2".toByteArray(), prfInput)
+        assertFalse(output1.contentEquals(output2))
+    }
+
+    @Test
+    fun `computeWebAuthnPrf matches expected computation`() {
+        val privateKeyBytes = "test-private-key".toByteArray(Charsets.UTF_8)
+        val prfInput = "test-prf-input".toByteArray(Charsets.UTF_8)
+
+        // Manually compute the expected output using the same algorithm
+        val prfSaltInput = PasskeyUtils.PRF_LABEL + prfInput
+        val prfSalt = MessageDigest.getInstance("SHA-256").digest(prfSaltInput)
+        val hmacKey = hmacSha256(privateKeyBytes, "prf".toByteArray(Charsets.UTF_8))
+        val expected = hmacSha256(hmacKey, prfSalt)
+
+        val actual = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
+        assertArrayEquals(expected, actual)
+    }
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray =
+        Mac.getInstance("HmacSHA256").run {
+            init(SecretKeySpec(key, "HmacSHA256"))
+            doFinal(data)
+        }
+}
+
+private class JvmCryptoGenerator : CryptoGenerator {
+    override fun hmac(key: ByteArray, data: ByteArray, algorithm: CryptoHashAlgorithm): ByteArray {
+        val name = when (algorithm) {
+            CryptoHashAlgorithm.SHA_1 -> "HmacSHA1"
+            CryptoHashAlgorithm.SHA_256 -> "HmacSHA256"
+            CryptoHashAlgorithm.SHA_512 -> "HmacSHA512"
+            CryptoHashAlgorithm.MD5 -> "HmacMD5"
+        }
+        return Mac.getInstance(name).run {
+            init(SecretKeySpec(key, name))
+            doFinal(data)
+        }
+    }
+
+    override fun hashSha256(data: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest(data)
+
+    override fun hashSha1(data: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-1").digest(data)
+
+    override fun hashMd5(data: ByteArray): ByteArray =
+        MessageDigest.getInstance("MD5").digest(data)
+
+    override fun hkdf(seed: ByteArray, salt: ByteArray?, info: ByteArray?, length: Int): ByteArray =
+        throw UnsupportedOperationException()
+
+    override fun pbkdf2(seed: ByteArray, salt: ByteArray, iterations: Int, length: Int): ByteArray =
+        throw UnsupportedOperationException()
+
+    override fun argon2(
+        mode: Argon2Mode,
+        seed: ByteArray,
+        salt: ByteArray,
+        iterations: Int,
+        memoryKb: Int,
+        parallelism: Int,
+    ): ByteArray = throw UnsupportedOperationException()
+
+    override fun seed(length: Int): ByteArray = ByteArray(length)
+
+    override fun uuid(): String = java.util.UUID.randomUUID().toString()
+
+    override fun random(): Int = 0
+
+    override fun random(range: IntRange): Int = range.first
+}

--- a/common/src/androidUnitTest/kotlin/com/artemchep/keyguard/android/PasskeyPrfTest.kt
+++ b/common/src/androidUnitTest/kotlin/com/artemchep/keyguard/android/PasskeyPrfTest.kt
@@ -17,7 +17,7 @@ class PasskeyPrfTest {
     fun `computeWebAuthnPrf returns 32 bytes`() {
         val output = computeWebAuthnPrf(
             cryptoGenerator,
-            privateKeyBytes = "private-key".toByteArray(),
+            prfSecretBytes = "prf-secret".toByteArray(),
             prfInput = "prf-input".toByteArray(),
         )
         org.junit.Assert.assertEquals(32, output.size)
@@ -25,42 +25,67 @@ class PasskeyPrfTest {
 
     @Test
     fun `computeWebAuthnPrf is deterministic for the same inputs`() {
-        val privateKeyBytes = "private-key".toByteArray()
+        val prfSecretBytes = "prf-secret".toByteArray()
         val prfInput = "prf-input".toByteArray()
-        val output1 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
-        val output2 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
+        val output1 = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, prfInput)
+        val output2 = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, prfInput)
         assertArrayEquals(output1, output2)
     }
 
     @Test
     fun `computeWebAuthnPrf different inputs produce different outputs`() {
-        val privateKeyBytes = "private-key".toByteArray()
-        val output1 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, "input-a".toByteArray())
-        val output2 = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, "input-b".toByteArray())
+        val prfSecretBytes = "prf-secret".toByteArray()
+        val output1 = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, "input-a".toByteArray())
+        val output2 = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, "input-b".toByteArray())
         assertFalse(output1.contentEquals(output2))
     }
 
     @Test
-    fun `computeWebAuthnPrf different keys produce different outputs`() {
+    fun `computeWebAuthnPrf different secrets produce different outputs`() {
         val prfInput = "prf-input".toByteArray()
-        val output1 = computeWebAuthnPrf(cryptoGenerator, "key-1".toByteArray(), prfInput)
-        val output2 = computeWebAuthnPrf(cryptoGenerator, "key-2".toByteArray(), prfInput)
+        val output1 = computeWebAuthnPrf(cryptoGenerator, "secret-1".toByteArray(), prfInput)
+        val output2 = computeWebAuthnPrf(cryptoGenerator, "secret-2".toByteArray(), prfInput)
         assertFalse(output1.contentEquals(output2))
     }
 
+    /**
+     * Verifies the algorithm is:
+     *   prfSalt   = SHA-256("WebAuthn PRF\x00" || prfInput)
+     *   prfOutput = HMAC-SHA-256(prfSecretBytes, prfSalt)
+     *
+     * The expected value is computed independently using raw JVM crypto so that
+     * the test does not simply re-execute the same code path it is testing.
+     */
     @Test
-    fun `computeWebAuthnPrf matches expected computation`() {
-        val privateKeyBytes = "test-private-key".toByteArray(Charsets.UTF_8)
+    fun `computeWebAuthnPrf matches W3C spec algorithm`() {
+        val prfSecretBytes = "test-prf-secret".toByteArray(Charsets.UTF_8)
         val prfInput = "test-prf-input".toByteArray(Charsets.UTF_8)
 
-        // Manually compute the expected output using the same algorithm
         val prfSaltInput = PasskeyUtils.PRF_LABEL + prfInput
         val prfSalt = MessageDigest.getInstance("SHA-256").digest(prfSaltInput)
-        val hmacKey = hmacSha256(privateKeyBytes, "prf".toByteArray(Charsets.UTF_8))
-        val expected = hmacSha256(hmacKey, prfSalt)
+        val expected = hmacSha256(prfSecretBytes, prfSalt)
 
-        val actual = computeWebAuthnPrf(cryptoGenerator, privateKeyBytes, prfInput)
+        val actual = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, prfInput)
         assertArrayEquals(expected, actual)
+    }
+
+    /**
+     * Verifies output does NOT equal the old (incorrect) two-step HMAC derivation that
+     * used the signing private key as key material, ensuring we produce a distinct value.
+     */
+    @Test
+    fun `computeWebAuthnPrf does not match old private-key-derived computation`() {
+        val signingKeyBytes = "signing-private-key".toByteArray(Charsets.UTF_8)
+        val prfSecretBytes = "separate-prf-secret".toByteArray(Charsets.UTF_8)
+        val prfInput = "test-input".toByteArray(Charsets.UTF_8)
+
+        val prfSalt = MessageDigest.getInstance("SHA-256").digest(PasskeyUtils.PRF_LABEL + prfInput)
+        // Old algorithm: HMAC-SHA-256(HMAC-SHA-256(signingKey, "prf"), prfSalt)
+        val oldHmacKey = hmacSha256(signingKeyBytes, "prf".toByteArray(Charsets.UTF_8))
+        val oldOutput = hmacSha256(oldHmacKey, prfSalt)
+
+        val newOutput = computeWebAuthnPrf(cryptoGenerator, prfSecretBytes, prfInput)
+        assertFalse("New output must differ from old private-key-derived output", newOutput.contentEquals(oldOutput))
     }
 
     private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray =

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/AddCredentialCipherRequest.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/AddCredentialCipherRequest.kt
@@ -8,6 +8,8 @@ data class AddCredentialCipherRequestPasskeyData(
     val keyAlgorithm: String, // ECDSA
     val keyCurve: String, // P-256
     val keyValue: String,
+    /** Base64-encoded 32-byte random secret used as HMAC key for PRF. */
+    val prfSecret: String,
     val rpId: String,
     val rpName: String?,
     val counter: Int?,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/DSecret.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/model/DSecret.kt
@@ -344,6 +344,8 @@ data class DSecret(
             val keyAlgorithm: String, // ECDSA
             val keyCurve: String, // P-256
             val keyValue: String,
+            /** Base64-encoded 32-byte random secret used as HMAC key for PRF (the "credRandom" equivalent). */
+            val prfSecret: String? = null,
             val rpId: String,
             val rpName: String?,
             val counter: Int?,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/common/service/passkey/entity/CreatePasskeyRequest.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/common/service/passkey/entity/CreatePasskeyRequest.kt
@@ -85,6 +85,23 @@ data class CreatePasskeyAuthenticatorSelection(
     val userVerification: String? = null,
 )
 
+// https://www.w3.org/TR/webauthn-3/#prf-extension
+@Serializable
+data class CreatePasskeyPrfEvalInput(
+    val first: String,
+    val second: String? = null,
+)
+
+@Serializable
+data class CreatePasskeyPrfExtension(
+    val eval: CreatePasskeyPrfEvalInput? = null,
+)
+
+@Serializable
+data class CreatePasskeyExtensions(
+    val prf: CreatePasskeyPrfExtension? = null,
+)
+
 /*
  * {
  * "attestation":"none",
@@ -138,4 +155,5 @@ data class CreatePasskey(
      * to a prompt for registration before an error is returned.
      */
     val timeout: Double? = null,
+    val extensions: CreatePasskeyExtensions? = null,
 )

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/core/store/bitwarden/BitwardenCipher.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/core/store/bitwarden/BitwardenCipher.kt
@@ -324,6 +324,7 @@ data class BitwardenCipher(
             val keyAlgorithm: String,
             val keyCurve: String,
             val keyValue: String,
+            val prfSecret: String? = null,
             val rpId: String,
             val rpName: String?,
             val counter: String,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/crypto/CipherCrypto.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/crypto/CipherCrypto.kt
@@ -150,6 +150,7 @@ fun BitwardenCipher.Login.Fido2Credentials.transform(
     keyAlgorithm = crypto.transformString(keyAlgorithm),
     keyCurve = crypto.transformString(keyCurve),
     keyValue = crypto.transformString(keyValue),
+    prfSecret = crypto.transformString(prfSecret),
     rpId = crypto.transformString(rpId),
     rpName = crypto.transformString(rpName),
     counter = crypto.transformString(counter),

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/crypto/CipherDecoder.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/crypto/CipherDecoder.kt
@@ -119,6 +119,7 @@ fun BitwardenCipher.Companion.encrypted(
                                 keyAlgorithm = it.keyAlgorithm,
                                 keyCurve = it.keyCurve,
                                 keyValue = it.keyValue,
+                                prfSecret = it.prfSecret,
                                 rpId = it.rpId,
                                 rpName = it.rpName,
                                 counter = it.counter,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/LoginFido2CredentialsEntity.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/LoginFido2CredentialsEntity.kt
@@ -22,6 +22,9 @@ data class LoginFido2CredentialsEntity(
     @JsonNames("keyValue")
     @SerialName("KeyValue")
     val keyValue: String,
+    @JsonNames("prfSecret")
+    @SerialName("PrfSecret")
+    val prfSecret: String? = null,
     @JsonNames("rpId")
     @SerialName("RpId")
     val rpId: String,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/api/LoginFido2CredentialsRequest.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/entity/api/LoginFido2CredentialsRequest.kt
@@ -18,6 +18,8 @@ data class LoginFido2CredentialsRequest(
     val keyCurve: String,
     @SerialName("keyValue")
     val keyValue: String,
+    @SerialName("prfSecret")
+    val prfSecret: String? = null,
     @SerialName("rpId")
     val rpId: String,
     @SerialName("rpName")
@@ -47,6 +49,7 @@ fun LoginFido2CredentialsRequest.Companion.of(
         keyAlgorithm = model.keyAlgorithm,
         keyCurve = model.keyCurve,
         keyValue = model.keyValue,
+        prfSecret = model.prfSecret,
         rpId = model.rpId,
         rpName = model.rpName,
         counter = model.counter,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/mapper/CipherMapping.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/mapper/CipherMapping.kt
@@ -209,6 +209,7 @@ fun BitwardenCipher.Login.Fido2Credentials.toDomain() = kotlin.run {
         keyAlgorithm = keyAlgorithm,
         keyCurve = keyCurve,
         keyValue = keyValue,
+        prfSecret = prfSecret,
         rpId = rpId,
         rpName = rpName,
         counter = counter,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/usecase/AddCipher.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/usecase/AddCipher.kt
@@ -850,6 +850,7 @@ internal suspend fun BitwardenCipher.Login.Companion.of(
                 keyAlgorithm = it.keyAlgorithm,
                 keyCurve = it.keyCurve,
                 keyValue = it.keyValue,
+                prfSecret = it.prfSecret,
                 rpId = it.rpId,
                 rpName = it.rpName,
                 counter = it.counter?.toString() ?: "",

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/usecase/AddCredentialCipher.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/usecase/AddCredentialCipher.kt
@@ -88,6 +88,7 @@ class AddCredentialCipherImpl(
                 keyAlgorithm = data.keyAlgorithm,
                 keyCurve = data.keyCurve,
                 keyValue = data.keyValue,
+                prfSecret = data.prfSecret,
                 rpId = data.rpId,
                 rpName = data.rpName,
                 counter = data.counter?.toString().orEmpty(),


### PR DESCRIPTION
Hi, huge Keyguard fan here. I hope this contribution finds you well. I wanted to use passkeys to derive an AES key in my website. I learned that the feature is supported in Google Password and Apple's Password manager but not (yet) for Keyguard. Normally I wouldn't allow Claude to make a PR for me, but because WebAuthn is a well-defined specification, I am more confident that it is probably implemented correctly. I did manually test it as well, using a debug build APK and Android/Firefox/Keyguard and it worked.

---


The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) lets relying parties derive deterministic symmetric keys from a passkey — enabling phishing-resistant **end-to-end encryption**. See [Corbado's writeup](https://www.corbado.com/blog/passkeys-prf-webauthn) for use cases.

**Changes** (all in `:common`):
- Registration: return `clientExtensionResults.prf.enabled = true` when `extensions.prf` is requested
- Authentication: compute and return `clientExtensionResults.prf.results` from `extensions.prf.eval` / `evalByCredential`
- CTAP 2.2+: return PRF results immediately at creation time when `extensions.prf.eval` is included
- Unit tests for the PRF computation

**Manually Tested** against https://webauthn-passkeys-prf-demo.explore.corbado.com/ on Mobile Firefox 151 / Android 16:

<!-- drag screenshot here -->
<img width="1439" height="1712" alt="Screenshot_2026-05-25-01-10-12-72_3aea4af51f236e4932235fdada7d1643" src="https://github.com/user-attachments/assets/1b112ae5-b2d3-4ab7-9e92-620f46c6af4d" />



