### PR TITLE
fix(Desktop): Mark concealed Linux clipboard contents as sensitive

### DIFF
--- a/common/src/desktopMain/kotlin/com/artemchep/keyguard/copy/ClipboardServiceJvm.kt
+++ b/common/src/desktopMain/kotlin/com/artemchep/keyguard/copy/ClipboardServiceJvm.kt
@@ -3,6 +3,8 @@ package com.artemchep.keyguard.copy
 import com.artemchep.keyguard.common.service.clipboard.ClipboardService
 import com.artemchep.keyguard.common.usecase.GetClipboardAutoClear
 import com.artemchep.keyguard.common.usecase.WindowCoroutineScope
+import com.artemchep.keyguard.platform.CurrentPlatform
+import com.artemchep.keyguard.platform.Platform
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -12,6 +14,8 @@ import org.kodein.di.instance
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.SystemFlavorMap
+import java.awt.datatransfer.Transferable
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
 
@@ -31,19 +35,26 @@ class ClipboardServiceJvm(
     private var autoClearJob: Job? = null
 
     override fun setPrimaryClip(value: String, concealed: Boolean) {
-        internalSetPrimaryClip(value)
+        internalSetPrimaryClip(value, concealed = concealed)
         scheduleAutoClear(value)
     }
 
     override fun clearPrimaryClip() {
         cancelAutoClear()
-        internalSetPrimaryClip("")
+        internalSetPrimaryClip("", concealed = false)
     }
 
     override fun hasCopyNotification(): Boolean = false
 
-    private fun internalSetPrimaryClip(value: String) {
-        val selection = StringSelection(value)
+    private fun internalSetPrimaryClip(
+        value: String,
+        concealed: Boolean,
+    ) {
+        val selection = if (concealed && CurrentPlatform is Platform.Desktop.Linux) {
+            SensitiveStringSelection(value)
+        } else {
+            StringSelection(value)
+        }
         Toolkit.getDefaultToolkit()
             .systemClipboard
             .setContents(selection, null)
@@ -110,4 +121,39 @@ class ClipboardServiceJvm(
             .systemClipboard
             .getData(DataFlavor.stringFlavor) as? String
     }.getOrNull()
+}
+
+private class SensitiveStringSelection(
+    value: String,
+) : Transferable {
+    private val textSelection = StringSelection(value)
+
+    override fun getTransferDataFlavors(): Array<DataFlavor> =
+        textSelection.transferDataFlavors + kdePasswordManagerHintFlavor
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+        textSelection.isDataFlavorSupported(flavor) ||
+                flavor == kdePasswordManagerHintFlavor
+
+    override fun getTransferData(flavor: DataFlavor): Any = when {
+        flavor == kdePasswordManagerHintFlavor -> kdePasswordManagerHintValue.copyOf()
+        else -> textSelection.getTransferData(flavor)
+    }
+
+    companion object {
+        private const val KDE_PASSWORD_MANAGER_HINT_NATIVE = "x-kde-passwordManagerHint"
+        private const val KDE_PASSWORD_MANAGER_HINT_MIME = "application/x-kde-password-manager-hint;class=\"[B\""
+
+        private val kdePasswordManagerHintValue = "secret".encodeToByteArray()
+        private val kdePasswordManagerHintFlavor = DataFlavor(
+            KDE_PASSWORD_MANAGER_HINT_MIME,
+            KDE_PASSWORD_MANAGER_HINT_NATIVE,
+        ).also { flavor ->
+            val flavorMap = SystemFlavorMap.getDefaultFlavorMap() as? SystemFlavorMap
+            flavorMap?.setNativesForFlavor(
+                flavor,
+                arrayOf(KDE_PASSWORD_MANAGER_HINT_NATIVE),
+            )
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for the `x-kde-passwordManagerHint` clipboard MIME entry on Linux Desktop. KeePassXC and Bitwarden support this hint, and it has become a de facto standard on Linux: many clipboard managers recognize it and exclude matching clipboard contents from history. Adding this support in Keyguard is therefore a reasonable way to protect concealed clipboard values consistently with the wider Linux ecosystem.