### PR TITLE
Add required display length for flatpak metadata

### DIFF
--- a/desktopApp/flatpak/com.artemchep.keyguard.metainfo.xml
+++ b/desktopApp/flatpak/com.artemchep.keyguard.metainfo.xml
@@ -14,6 +14,9 @@
   </branding>
   <metadata_license>FSFAP</metadata_license>
   <project_license>LicenseRef-proprietary=https://github.com/AChep/keyguard-app/blob/master/LICENSE</project_license>
+  <required>
+    <display_length compare="ge">360</display_length>
+  </required>
   <supports>
     <control>pointing</control>
     <control>keyboard</control>

--- a/desktopApp/flatpak/com.artemchep.keyguard.metainfo.xml
+++ b/desktopApp/flatpak/com.artemchep.keyguard.metainfo.xml
@@ -14,9 +14,9 @@
   </branding>
   <metadata_license>FSFAP</metadata_license>
   <project_license>LicenseRef-proprietary=https://github.com/AChep/keyguard-app/blob/master/LICENSE</project_license>
-  <required>
+  <requires>
     <display_length compare="ge">360</display_length>
-  </required>
+  </requires>
   <supports>
     <control>pointing</control>
     <control>keyboard</control>


### PR DESCRIPTION
this tells flathub to treat the app as mobile layout capable. flathub than can showcase the app in mobile apps category

relevant flathub [docs](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#device-support:~:text=A%20value%20of%20%3C%3D360%20with%20the%20ge%20relation%20indicates%20that%20the%20app%20supports%20mobile%2C%20tablet%20and%20desktop%20devices%2E%20Usually%20360%20is%20used%20as%20a%20baseline%20here)