### PR TITLE
fix(listing,wiki): correct screenshort and exlcuding typos

### DIFF
--- a/listing/common/af-rZA/listing.xml
+++ b/listing/common/af-rZA/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Skep wagwoorde, SSH-sleutels en e-pos-aanstuurders, met ondersteuning vir pasgemaakte woordelyste.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Gevorderde kenmerke: Ondersteuning vir kortpaaie, veldplashouers, URL-oorskrywings en slim konflikoplossing.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Tuisskerm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Tuisskerm, donker tema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-skerm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-skerm</string>
 </resources>

--- a/listing/common/ar-rSA/listing.xml
+++ b/listing/common/ar-rSA/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/base/listing.xml
+++ b/listing/common/base/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/bn-rBD/listing.xml
+++ b/listing/common/bn-rBD/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">জেনারেটর: কাস্টম শব্দতালিকার সুবিধাসহ পাসওয়ার্ড, SSH কী, এবং ইমেইল ফরোয়ার্ড তৈরি করুন।</string>
     <string name="listing_description_highlight_ssh_agent">SSH এজেন্ট: সার্ভারে যাচাই করা, গিট কমিট সাক্ষর করা, SSH-ভিত্তিক পরিষেবাগুলোর সাথে কাজ করা।</string>
     <string name="listing_description_highlight_other">উন্নত বৈশিষ্ট্যগুলো: শর্টকাটের সুবিধা, ফিল্ডের প্লেসহোল্ডার, URL পরিবর্তন করা, এবং স্মার্ট সমস্যার সমাধান।</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">হোম স্ক্রিন</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">হোম স্কিন, ডার্ক থিম</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">জেনেরেটর স্ক্রিন</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">ওয়াচটাওয়ার স্ক্রিন</string>
 </resources>

--- a/listing/common/ca-rES/listing.xml
+++ b/listing/common/ca-rES/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generador: Crea contrasenyes, claus SSH i reenviadors de correu, amb suport per a llistes de paraules personalitzades.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Funcions avançades: Suport per a dreceres, marcadors de posició de camps, substitucions d\'URL i resolució intel·ligent de conflictes.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Pantalla d\'inici</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Pantalla d\'inici, tema fosc</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Pantalla del generador</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Pantalla de Watchtower</string>
 </resources>

--- a/listing/common/cs-rCZ/listing.xml
+++ b/listing/common/cs-rCZ/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generátor: Vytvářejte hesla, SSH klíče a e-mailové přesměrování, s podporou vlastních seznamů slov.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Pokročilé funkce: Podpora zkratek, zástupných symbolů polí, přepisovc URL a inteligentního řešení konfliktů.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Domovská obrazovka</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Domovská obrazovka, tmavý motiv</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Obrazovka generátoru</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Obrazovka Watchtower</string>
 </resources>

--- a/listing/common/da-rDK/listing.xml
+++ b/listing/common/da-rDK/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Opret adgangskoder, SSH-nøgler og e-mail-videresendelser, med understøttelse af brugerdefinerede ordlister.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Avancerede funktioner: Understøttelse af genveje, feltpladsholdere, URL-tilsidesættelser og smart konfliktløsning.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Startskærm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Startskærm, mørkt tema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-skærm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-skærm</string>
 </resources>

--- a/listing/common/de-rDE/listing.xml
+++ b/listing/common/de-rDE/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Passwörter, SSH-Schlüssel und E-Mail-Weiterleitungen erstellen, mit Unterstützung für benutzerdefinierte Wortlisten.</string>
     <string name="listing_description_highlight_ssh_agent">SSH-Agent: Authentifizierung gegenüber Servern, Signierung von Git-Commits, Interaktion mit SSH-basierten Diensten.</string>
     <string name="listing_description_highlight_other">Erweiterte Funktionen: Unterstützung für Tastenkombinationen, Feld-Platzhalter, URL-Überschreibungen und intelligente Konfliktlösung.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Startbildschirm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Startbildschirm, dunkles Thema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-Bildschirm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-Bildschirm</string>
 </resources>

--- a/listing/common/el-rGR/listing.xml
+++ b/listing/common/el-rGR/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/en-rGB/listing.xml
+++ b/listing/common/en-rGB/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/en-rUS/listing.xml
+++ b/listing/common/en-rUS/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/es-rES/listing.xml
+++ b/listing/common/es-rES/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generador: Crear contraseñas, claves SSH y reenviadores de correo, con soporte para listas de palabras personalizadas.</string>
     <string name="listing_description_highlight_ssh_agent">Agente de SSH: Autenticando a los servidores, Firmando compromisos de Git, Interactuando con servicios basados en SSH.</string>
     <string name="listing_description_highlight_other">Funciones avanzadas: Soporte para atajos, marcadores de posición de campos, anulaciones de URL y resolución inteligente de conflictos.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Pantalla de inicio</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Pantalla de inicio, tema oscuro</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Pantalla del generador</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Pantalla de Watchtower</string>
 </resources>

--- a/listing/common/fi-rFI/listing.xml
+++ b/listing/common/fi-rFI/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/fr-rFR/listing.xml
+++ b/listing/common/fr-rFR/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Générateur : Créer des mots de passe, des clés SSH et des redirections d\'e-mails, avec support des listes de mots personnalisées.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Fonctionnalités avancées : Support des raccourcis, espaces réservés de champs, substitutions d\'URL et résolution intelligente des conflits.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Écran d\'accueil</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Écran d\'accueil, thème sombre</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Écran du générateur</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Écran Watchtower</string>
 </resources>

--- a/listing/common/hu-rHU/listing.xml
+++ b/listing/common/hu-rHU/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generátor: Jelszavak, SSH-kulcsok és e-mail továbbítók létrehozása, egyéni szójegyzékek támogatásával.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Fejlett funkciók: Parancsikonok, mező-helyőrzők (placeholderek), URL-felülbírálások és intelligens ütközésfeloldás támogatása.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Kezdőképernyő</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Kezdőképernyő, sötét téma</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generátor képernyő</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Őrtorony képernyő</string>
 </resources>

--- a/listing/common/it-rIT/listing.xml
+++ b/listing/common/it-rIT/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generatore: Crea password, chiavi SSH e inoltri email, con supporto per liste di parole personalizzate.</string>
     <string name="listing_description_highlight_ssh_agent">Agente SSH: Autenticazione ai server, firma dei commit Git, interazione con servizi basati su SSH.</string>
     <string name="listing_description_highlight_other">Funzionalità avanzate: Supporto per scorciatoie, segnaposto dei campi, sovrascritture URL e risoluzione intelligente dei conflitti.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Schermata iniziale</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Schermata iniziale, tema scuro</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Schermata del generatore</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Schermata Watchtower</string>
 </resources>

--- a/listing/common/iw-rIL/listing.xml
+++ b/listing/common/iw-rIL/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/ja-rJP/listing.xml
+++ b/listing/common/ja-rJP/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/ko-rKR/listing.xml
+++ b/listing/common/ko-rKR/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">홈 화면</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">홈 화면, 다크 테마</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">생성기 화면</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">감시탑 화면</string>
 </resources>

--- a/listing/common/nl-rNL/listing.xml
+++ b/listing/common/nl-rNL/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Wachtwoorden, SSH-sleutels en e-mail doorstuurders maken, met ondersteuning voor aangepaste woordenlijsten.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Geavanceerde functies: Ondersteuning voor sneltoetsen, veldplaatshouders, URL-overschrijvingen en slimme conflictoplossing.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Startscherm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Startscherm, donker thema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-scherm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-scherm</string>
 </resources>

--- a/listing/common/no-rNO/listing.xml
+++ b/listing/common/no-rNO/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Opprett passord, SSH-nøkler og e-postvideresendere, med støtte for egendefinerte ordlister.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Avanserte funksjoner: Støtte for snarveier, feltplassholdere, URL-overstyringer og smart konfliktløsning.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Hjemskjerm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Hjemskjerm, mørkt tema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-skjerm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-skjerm</string>
 </resources>

--- a/listing/common/pl-rPL/listing.xml
+++ b/listing/common/pl-rPL/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Twórz hasła, klucze SSH i przekierowania e-mail, z obsługą niestandardowych list słów.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Zaawansowane funkcje: Obsługa skrótów, symbol zastępczych pól, nadpisywania URL i inteligentnego rozwiązywania konfliktów.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Ekran główny</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Ekran główny, ciemny motyw</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Ekran generatora</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Ekran Watchtower</string>
 </resources>

--- a/listing/common/pt-rBR/listing.xml
+++ b/listing/common/pt-rBR/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Gerador: Crie senhas, chaves SSH e encaminhadores de e-mail, com suporte para listas de palavras personalizadas.</string>
     <string name="listing_description_highlight_ssh_agent">Agente SSH: Autenticação em servidores, Assinatura de commits Git, Interação com serviços baseados em SSH.</string>
     <string name="listing_description_highlight_other">Recursos Avançados: Suporte para atalhos, espaços reservados, substituições de URLs, e resolução inteligente de conflitos.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Tela inicial</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Tela inicial, tema escuro</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Tela geradora</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Tela da Torre de Vigia</string>
 </resources>

--- a/listing/common/pt-rPT/listing.xml
+++ b/listing/common/pt-rPT/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Gerador: Crie palavras-passe, chaves SSH e encaminhadores de e-mail, com suporte para listas de palavras personalizadas.</string>
     <string name="listing_description_highlight_ssh_agent">Agente SSH: Autenticação em servidores, assinatura de commits Git, interação com serviços baseados em SSH.</string>
     <string name="listing_description_highlight_other">Funcionalidades avançadas: Suporte para atalhos, espaços reservados de campos, substituição de URLs e resolução inteligente de conflitos.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Ecrã inicial</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Ecrã inicial, tema escuro</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Ecrã do gerador</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Ecrã do guardião</string>
 </resources>

--- a/listing/common/ro-rRO/listing.xml
+++ b/listing/common/ro-rRO/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Creați parole, chei SSH și redirectoare de e-mail, cu suport pentru liste de cuvinte personalizate.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Funcții avansate: Suport pentru comenzi rapide, substituitori de câmpuri, suprascrieri URL și rezolvare inteligentă a conflictelor.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Ecran principal</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Ecran principal, temă întunecată</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Ecran generator</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Ecran Watchtower</string>
 </resources>

--- a/listing/common/ru-rRU/listing.xml
+++ b/listing/common/ru-rRU/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Генератор: Создавайте пароли, SSH-ключи и пересылку электронной почты, с поддержкой пользовательских словарей.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Расширенные функции: Поддержка горячих клавиш, плейсхолдеров полей, переопределения URL и умного разрешения конфликтов.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Главный экран</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Главный экран, тёмная тема</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Экран генератора</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Экран Watchtower</string>
 </resources>

--- a/listing/common/sr-rSP/listing.xml
+++ b/listing/common/sr-rSP/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Генератор: Креирајте лозинке, SSH кључеве и прослеђиваче е-поште, са подршком за прилагођене листе речи.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Напредне функције: Подршка за пречице, чуваре места поља, URL замене и паметно решавање конфликата.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Почетни екран</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Почетни екран, тамна тема</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Екран генератора</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower екран</string>
 </resources>

--- a/listing/common/sv-rSE/listing.xml
+++ b/listing/common/sv-rSE/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Skapa lösenord, SSH-nycklar och e-postvidarebefordrare, med stöd för anpassade ordlistor.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Avancerade funktioner: Stöd för genvägar, fältplatshållare, URL-åsidosättningar och smart konfliktlösning.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Hemskärm</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Hemskärm, mörkt tema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator-skärm</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower-skärm</string>
 </resources>

--- a/listing/common/tr-rTR/listing.xml
+++ b/listing/common/tr-rTR/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Oluşturucu: Özel kelime listesi desteğiyle parolalar, SSH anahtarları ve e-posta yönlendiricileri oluşturun.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Aracısı: Sunucularda kimlik doğrulaması yapın, Git işlemelerini (commits) imzalayın ve SSH tabanlı servislerle etkileşime geçin.</string>
     <string name="listing_description_highlight_other">Gelişmiş Özellikler: Kısayollar, alan yer tutucuları (placeholders), URL geçersiz kılmaları (overrides) ve akıllı çakışma çözümü desteği.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Ana ekran</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Ana ekran, koyu tema</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Oluşturucu ekranı</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower ekranı</string>
 </resources>

--- a/listing/common/uk-rUA/listing.xml
+++ b/listing/common/uk-rUA/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Генератор: Створюйте паролі, SSH-ключі та пересилачі пошти (email forwarders), з підтримкою власних словників.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Розширені функції: Підтримка клавіатури, перевизначення URL-адрес та розумне вирішення конфліктів.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Головний екран</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Головний екран, темна тема</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Екран генератора</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Екран вартової вежі</string>
 </resources>

--- a/listing/common/vi-rVN/listing.xml
+++ b/listing/common/vi-rVN/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">Generator: Create passwords, SSH keys and email forwarders, with support for custom wordlists.</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">Advanced Features: Support for shortcuts, Field placeholders, URL overrides, and smart conflict resolution.</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">Home screen</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">Home screen, dark theme</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">Generator screen</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower screen</string>
 </resources>

--- a/listing/common/zh-rCN/listing.xml
+++ b/listing/common/zh-rCN/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">生成器：创建密码、SSH 密钥和电子邮件转发器，支持自定义字典。</string>
     <string name="listing_description_highlight_ssh_agent">SSH 代理：对服务器进行身份验证、签名 Git 提交、与基于 SSH 的服务进行交互。</string>
     <string name="listing_description_highlight_other">高级功能：支持快捷方式、字段占位符、URL 覆盖和智能冲突解决。</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">主界面</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">主屏幕，深色主题</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">生成器界面</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">Watchtower 界面</string>
 </resources>

--- a/listing/common/zh-rTW/listing.xml
+++ b/listing/common/zh-rTW/listing.xml
@@ -16,12 +16,12 @@
     <string name="listing_description_highlight_generator">生成器：建立密碼、SSH 金鑰和電子郵件轉發器，支援自訂詞條。</string>
     <string name="listing_description_highlight_ssh_agent">SSH Agent: Authenticating to servers, Signing Git commits, Interacting with SSH-based services.</string>
     <string name="listing_description_highlight_other">進階功能：支援快捷方式、欄位提示文字、網址覆寫和智慧衝突解決。</string>
-    <!-- A content description shown below the Home screenshort, made with the default settings -->
+    <!-- A content description shown below the Home screenshot, made with the default settings -->
     <string name="listing_screenshot_home_default">首頁</string>
-    <!-- A content description shown below the Home screenshort, made with the dark theme settings -->
+    <!-- A content description shown below the Home screenshot, made with the dark theme settings -->
     <string name="listing_screenshot_home_dark">首頁，暗色主題</string>
-    <!-- A content description shown below the Generator screenshort, made with the default settings -->
+    <!-- A content description shown below the Generator screenshot, made with the default settings -->
     <string name="listing_screenshot_generator_default">生成器畫面</string>
-    <!-- A content description shown below the Watchtower screenshort, made with the default settings -->
+    <!-- A content description shown below the Watchtower screenshot, made with the default settings -->
     <string name="listing_screenshot_watchtower_default">瞭望塔畫面</string>
 </resources>

--- a/wiki/VAULT_SEARCH.md
+++ b/wiki/VAULT_SEARCH.md
@@ -47,4 +47,4 @@ Use `qualifier:value` to search in a specific field.
 | `github -personal`                  | Finds items related to `github`, excluding ones that match `personal`.         |
 | `title:github username:alice`       | Searches for `github` in titles and `alice` in usernames.                      |
 | `title:github note:"shared access"` | Searches for `github` in titles and `shared access` in notes.                  |
-| `domain:example -tag:archive`       | Searches for `example` in domains, exlcuding results that match `archive` tag. |
+| `domain:example -tag:archive`       | Searches for `example` in domains, excluding results that match `archive` tag. |


### PR DESCRIPTION
## Summary

Typo corrections in XML comments and documentation:

- `screenshort` → `screenshot` in 33 locale `listing.xml` files (XML comments)
- `exlcuding` → `excluding` in `wiki/VAULT_SEARCH.md`

## Details

The `screenshort` typo was introduced in commit `de8b4d28` when the automated localization bot generated all locale listing files from a template that contained the misspelling. Since these are XML comments only, they have no runtime impact but affect code quality.

Closes #1471

## Changes

- 33 locale `listing.xml` files: fixed `screenshort` → `screenshot` in XML comments
- `wiki/VAULT_SEARCH.md`: fixed `exlcuding` → `excluding`