### PR TITLE
fix: close cipher selection bar when selected items no longer exist

### DIFF
--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/duplicates/list/DuplicatesListStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/duplicates/list/DuplicatesListStateProducer.kt
@@ -80,6 +80,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.kodein.di.DirectDI
 import org.kodein.di.compose.localDI
 import org.kodein.di.direct
@@ -402,12 +404,29 @@ fun RememberStateFlowScope.createCipherSelectionFlow(
     confirmationRouteFactory: ConfirmationRouteFactory,
     //
     toolbox: CipherToolbox,
-) = combine(
-    ciphersFlow,
-    selectionHandle.idsFlow,
-    collectionsFlow,
-    canWriteFlow,
-) { ciphers, selectedCipherIds, collections, canWrite ->
+): Flow<Selection?> {
+    // Automatically remove selection from ciphers
+    // that do not exist anymore.
+    ciphersFlow
+        .onEach { ciphers ->
+            val selectedItemIds = selectionHandle.idsFlow.value
+            val filteredSelectedItemIds = selectedItemIds
+                .filter { itemId ->
+                    ciphers.any { it.id == itemId }
+                }
+                .toSet()
+            if (filteredSelectedItemIds.size < selectedItemIds.size) {
+                selectionHandle.setSelection(filteredSelectedItemIds)
+            }
+        }
+        .launchIn(this)
+
+    return combine(
+        ciphersFlow,
+        selectionHandle.idsFlow,
+        collectionsFlow,
+        canWriteFlow,
+    ) { ciphers, selectedCipherIds, collections, canWrite ->
     val selectedCiphers = ciphers
         .filter { it.id in selectedCipherIds }
     // Hide the selection bar based on the ciphers that actually still exist,
@@ -643,4 +662,5 @@ fun RememberStateFlowScope.createCipherSelectionFlow(
         actions = actions.toPersistentList(),
         onClear = selectionHandle::clearSelection,
     )
+}
 }

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/duplicates/list/DuplicatesListStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/duplicates/list/DuplicatesListStateProducer.kt
@@ -408,12 +408,15 @@ fun RememberStateFlowScope.createCipherSelectionFlow(
     collectionsFlow,
     canWriteFlow,
 ) { ciphers, selectedCipherIds, collections, canWrite ->
-    if (selectedCipherIds.isEmpty()) {
+    val selectedCiphers = ciphers
+        .filter { it.id in selectedCipherIds }
+    // Hide the selection bar based on the ciphers that actually still exist,
+    // not the raw id set. After a delete/merge the removed ids linger in the
+    // selection handle; keying off the filtered list lets the bar close itself.
+    if (selectedCiphers.isEmpty()) {
         return@combine null
     }
 
-    val selectedCiphers = ciphers
-        .filter { it.id in selectedCipherIds }
     val selectedCiphersByAccount = selectedCiphers
         .groupBy { it.accountId }
 

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/screen/VaultListStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/screen/VaultListStateProducer.kt
@@ -484,7 +484,19 @@ internal fun vaultListScreenState(
             val selectedItemIds = selectionHandle.idsFlow.value
             val filteredSelectedItemIds = selectedItemIds
                 .filter { itemId ->
-                    ciphers.any { it.id == itemId }
+                    val cipher = ciphers.firstOrNull { it.id == itemId }
+                    if (cipher == null) return@filter false
+                    val passesTrashFilter = when (args.trash) {
+                        true -> cipher.deletedDate != null
+                        false -> cipher.deletedDate == null
+                        null -> true
+                    }
+                    val passesArchiveFilter = when (args.archive) {
+                        true -> cipher.archivedDate != null
+                        false -> cipher.archivedDate == null
+                        null -> true
+                    }
+                    passesTrashFilter && passesArchiveFilter
                 }
                 .toSet()
             if (filteredSelectedItemIds.size < selectedItemIds.size) {


### PR DESCRIPTION
Fixes #1473.

**Problem:** After deleting, trashing, archiving or merging all selected items, the selection bar stays open showing "0 selected". The bar's visibility was keyed off the raw selected-id set, while the displayed count was computed from ids filtered against still-existing ciphers — so stale ids kept the bar open.

**Fix (3 commits):**
- Key the selection bar's empty-check off the filtered list of still-existing ciphers, so the bar closes itself once the selected ciphers are gone (shared `createCipherSelectionFlow`, affects vault list + duplicates).
- Automatically drop deleted cipher IDs from the selection handle on the duplicates screen.
- Automatically drop selected items from the selection when they are trashed or archived on the vault list.

Tested on desktop: select items → trash/merge all → selection bar now closes instead of lingering with "0 selected".