### PR TITLE
feat: Add link to other itemes

### DIFF
--- a/common/src/commonMain/composeResources/values/strings.xml
+++ b/common/src/commonMain/composeResources/values/strings.xml
@@ -1950,4 +1950,11 @@
     <string name="gpg_agent_history_clear_history_confirmation_title">Clear GPG agent history?</string>
     <string name="gpg_agent_history_clear_history_confirmation_text">This will remove all GPG agent usage history.</string>
 
+    <string name="cipher_links_outgoing_title">Linked items</string>
+    <string name="cipher_links_incoming_title">Referenced by</string>
+    <string name="cipher_link_unavailable_title">Item unavailable</string>
+    <string name="cipher_link_default_label">Linked item</string>
+    <string name="cipher_link_picker_title">Select linked item</string>
+    <string name="cipher_link_picker_action">Link to an item</string>
+
 </resources>

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/add/AddStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/add/AddStateProducer.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.DeleteForever
+import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Password
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
@@ -161,6 +162,8 @@ import com.artemchep.keyguard.feature.home.vault.add.attachment.SkeletonAttachme
 import com.artemchep.keyguard.feature.home.vault.add.attachment.toSkeletonAttachmentOrNull
 import com.artemchep.keyguard.feature.home.settings.accounts.model.AccountType
 import com.artemchep.keyguard.feature.home.vault.component.obscurePassword
+import com.artemchep.keyguard.feature.home.vault.link.CipherLinkPickerResult
+import com.artemchep.keyguard.feature.home.vault.link.CipherLinkPickerRoute
 import com.artemchep.keyguard.feature.home.vault.screen.VaultViewRoute
 import com.artemchep.keyguard.feature.localization.TextHolder
 import com.artemchep.keyguard.feature.localization.wrap
@@ -788,9 +791,20 @@ suspend fun RememberStateFlowScope.addCipherStateProducer(
         }
         .foldAsList()
 
+    val fieldAccountIdFlow = ownershipFlow
+        .map { it.data.accountId }
+        .distinctUntilChanged()
     val fieldsFactories = kotlin.run {
-        val plainTextFactory = AddStateItemFieldTextFactory(false)
-        val concealedTextFactory = AddStateItemFieldTextFactory(true)
+        val plainTextFactory = AddStateItemFieldTextFactory(
+            defaultConcealed = false,
+            accountIdFlow = fieldAccountIdFlow,
+            excludedCipherId = args.initialValue?.id,
+        )
+        val concealedTextFactory = AddStateItemFieldTextFactory(
+            defaultConcealed = true,
+            accountIdFlow = fieldAccountIdFlow,
+            excludedCipherId = args.initialValue?.id,
+        )
         val booleanFactory = AddStateItemFieldBooleanFactory()
         val linkedIdFactory = AddStateItemFieldLinkedIdFactory(
             typeFlow = typeFlow,
@@ -1623,6 +1637,8 @@ abstract class AddStateItemFieldFactory : Foo2Factory<AddStateItem.Field<*>, DSe
 
 class AddStateItemFieldTextFactory(
     private val defaultConcealed: Boolean = false,
+    private val accountIdFlow: Flow<String?>,
+    private val excludedCipherId: String?,
 ) : AddStateItemFieldFactory() {
     override val type: String = if (defaultConcealed) {
         "field.text_concealed"
@@ -1685,40 +1701,64 @@ class AddStateItemFieldTextFactory(
                 ?: defaultConcealed
         }
 
-        val actionsConcealItemFlow = concealSink
-            .map { conceal ->
-                FlatItemAction(
-                    id = "addItem.field.concealValue",
-                    leading = {
-                        val imageVector = if (conceal) {
-                            Icons.Outlined.VisibilityOff
-                        } else {
-                            Icons.Outlined.Visibility
-                        }
-                        Crossfade(targetState = imageVector) { iv ->
-                            IconBox(
-                                main = iv,
-                            )
-                        }
-                    },
-                    title = TextHolder.Res(Res.string.conceal_value),
-                    trailing = {
-                        Checkbox(
-                            checked = conceal,
-                            onCheckedChange = null,
+        val actionsFlow = combine(
+            concealSink,
+            accountIdFlow,
+        ) { conceal, accountId ->
+            val concealItem = FlatItemAction(
+                id = "addItem.field.concealValue",
+                leading = {
+                    val imageVector = if (conceal) {
+                        Icons.Outlined.VisibilityOff
+                    } else {
+                        Icons.Outlined.Visibility
+                    }
+                    Crossfade(targetState = imageVector) { iv ->
+                        IconBox(
+                            main = iv,
                         )
-                    },
-                    onClick = {
-                        concealSink.value = !conceal
-                    },
-                )
-            }
-        val actionsFlow = actionsConcealItemFlow
-            .map { concealItem ->
-                buildContextItems {
-                    this += concealItem
+                    }
+                },
+                title = TextHolder.Res(Res.string.conceal_value),
+                trailing = {
+                    Checkbox(
+                        checked = conceal,
+                        onCheckedChange = null,
+                    )
+                },
+                onClick = {
+                    concealSink.value = !conceal
+                },
+            )
+
+            buildContextItems {
+                if (!conceal && accountId != null) {
+                    this += FlatItemAction(
+                        id = "addItem.field.linkCipher",
+                        leading = icon(Icons.Outlined.Link),
+                        title = TextHolder.Res(Res.string.cipher_link_picker_action),
+                        trailing = {
+                            ChevronIcon()
+                        },
+                        onClick = {
+                            val pickerRoute = CipherLinkPickerRoute(
+                                args = CipherLinkPickerRoute.Args(
+                                    accountId = accountId,
+                                    excludedCipherId = excludedCipherId,
+                                ),
+                            )
+                            val route = registerRouteResultReceiver(pickerRoute) { result ->
+                                if (result is CipherLinkPickerResult.Confirm) {
+                                    textHandle.setText(result.link.toString())
+                                }
+                            }
+                            navigate(NavigationIntent.NavigateToRoute(route))
+                        },
+                    )
                 }
+                this += concealItem
             }
+        }
 
         val stateFlow = combine(
             labelFlow,

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLink.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLink.kt
@@ -1,0 +1,114 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import com.artemchep.keyguard.common.model.DSecret
+import kotlin.uuid.Uuid
+
+class CipherLink private constructor(
+    val remoteCipherId: String,
+) {
+    override fun toString(): String = "$SCHEME_PREFIX$remoteCipherId"
+
+    companion object {
+        const val SCHEME_PREFIX = "keyguard://cipher/"
+
+        fun of(remoteCipherId: String): CipherLink? = kotlin.runCatching {
+            CipherLink(Uuid.parse(remoteCipherId).toString())
+        }.getOrNull()
+
+        fun parse(value: String?): CipherLink? {
+            val normalizedValue = value?.trim().orEmpty()
+            if (!normalizedValue.startsWith(SCHEME_PREFIX)) {
+                return null
+            }
+            val remoteCipherId = normalizedValue.removePrefix(SCHEME_PREFIX)
+            if (
+                remoteCipherId.isEmpty() ||
+                remoteCipherId.any { it == '/' || it == '?' || it == '#' }
+            ) {
+                return null
+            }
+            return of(remoteCipherId)
+        }
+    }
+}
+
+data class CipherRelation(
+    val fieldIndex: Int,
+    val label: String,
+    val link: CipherLink,
+    val cipher: DSecret?,
+)
+
+data class CipherRelations(
+    val outgoing: List<CipherRelation>,
+    val incoming: List<CipherRelation>,
+)
+
+fun resolveCipherRelations(
+    cipher: DSecret,
+    ciphers: List<DSecret>,
+): CipherRelations {
+    val accountCiphers = ciphers
+        .asSequence()
+        .filter { it.accountId == cipher.accountId && it.deletedDate == null }
+        .toList()
+    val targetsByRemoteId = accountCiphers
+        .asSequence()
+        .filter { it.id != cipher.id }
+        .mapNotNull { target ->
+            target.service.remote?.id
+                ?.let(CipherLink::of)
+                ?.remoteCipherId
+                ?.let { it to target }
+        }
+        .toMap()
+
+    val outgoing = cipher.fields.mapIndexedNotNull { fieldIndex, field ->
+        if (field.type != DSecret.Field.Type.Text) {
+            return@mapIndexedNotNull null
+        }
+        val link = CipherLink.parse(field.value)
+            ?: return@mapIndexedNotNull null
+        CipherRelation(
+            fieldIndex = fieldIndex,
+            label = field.name.orEmpty(),
+            link = link,
+            cipher = targetsByRemoteId[link.remoteCipherId],
+        )
+    }
+
+    val currentRemoteId = cipher.service.remote?.id
+        ?.let(CipherLink::of)
+        ?.remoteCipherId
+    val incoming = if (currentRemoteId == null) {
+        emptyList()
+    } else {
+        accountCiphers
+            .asSequence()
+            .filter { it.id != cipher.id }
+            .flatMap { source ->
+                source.fields
+                    .asSequence()
+                    .mapIndexedNotNull { fieldIndex, field ->
+                        if (field.type != DSecret.Field.Type.Text) {
+                            return@mapIndexedNotNull null
+                        }
+                        val link = CipherLink.parse(field.value)
+                            ?.takeIf { it.remoteCipherId == currentRemoteId }
+                            ?: return@mapIndexedNotNull null
+                        CipherRelation(
+                            fieldIndex = fieldIndex,
+                            label = field.name.orEmpty(),
+                            link = link,
+                            cipher = source,
+                        )
+                    }
+            }
+            .toList()
+    }
+
+    return CipherRelations(
+        outgoing = outgoing,
+        incoming = incoming,
+    )
+}

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerRoute.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerRoute.kt
@@ -1,0 +1,32 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import androidx.compose.runtime.Composable
+import com.artemchep.keyguard.feature.navigation.DialogRouteForResult
+import com.artemchep.keyguard.feature.navigation.RouteResultTransmitter
+
+data class CipherLinkPickerRoute(
+    val args: Args,
+) : DialogRouteForResult<CipherLinkPickerResult> {
+    data class Args(
+        val accountId: String,
+        val excludedCipherId: String? = null,
+    )
+
+    @Composable
+    override fun Content(
+        transmitter: RouteResultTransmitter<CipherLinkPickerResult>,
+    ) {
+        CipherLinkPickerScreen(
+            args = args,
+            transmitter = transmitter,
+        )
+    }
+}
+
+sealed interface CipherLinkPickerResult {
+    data class Confirm(
+        val link: CipherLink,
+    ) : CipherLinkPickerResult
+
+    data object Deny : CipherLinkPickerResult
+}

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerScreen.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerScreen.kt
@@ -1,0 +1,121 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.artemchep.keyguard.common.model.ShapeState
+import com.artemchep.keyguard.feature.dialog.Dialog
+import com.artemchep.keyguard.feature.home.vault.component.FlatItemSimpleExpressive
+import com.artemchep.keyguard.feature.home.vault.component.VaultItemIcon2
+import com.artemchep.keyguard.feature.navigation.RouteResultTransmitter
+import com.artemchep.keyguard.res.Res
+import com.artemchep.keyguard.res.*
+import com.artemchep.keyguard.ui.FlatTextField
+import com.artemchep.keyguard.ui.MediumEmphasisAlpha
+import com.artemchep.keyguard.ui.icons.ChevronIcon
+import com.artemchep.keyguard.ui.icons.icon
+import com.artemchep.keyguard.ui.theme.Dimens
+import com.artemchep.keyguard.ui.theme.combineAlpha
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun CipherLinkPickerScreen(
+    args: CipherLinkPickerRoute.Args,
+    transmitter: RouteResultTransmitter<CipherLinkPickerResult>,
+) {
+    val state = produceCipherLinkPickerState(
+        args = args,
+        transmitter = transmitter,
+    )
+    Dialog(
+        icon = icon(Icons.Outlined.Link),
+        title = {
+            Text(stringResource(Res.string.cipher_link_picker_title))
+        },
+        contentScrollable = false,
+        content = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                FlatTextField(
+                    modifier = Modifier
+                        .padding(horizontal = Dimens.fieldHorizontalPadding),
+                    value = state.query,
+                    placeholder = stringResource(Res.string.vault_main_search_placeholder),
+                    singleLine = true,
+                )
+                Spacer(Modifier.height(12.dp))
+                if (state.items.isEmpty()) {
+                    Text(
+                        modifier = Modifier
+                            .padding(horizontal = Dimens.horizontalPadding),
+                        text = stringResource(Res.string.items_empty_label),
+                        color = LocalContentColor.current
+                            .combineAlpha(MediumEmphasisAlpha),
+                    )
+                    Spacer(Modifier.height(16.dp))
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 440.dp),
+                    ) {
+                        items(
+                            items = state.items,
+                            key = CipherLinkPickerState.Item::id,
+                        ) { item ->
+                            FlatItemSimpleExpressive(
+                                shapeState = ShapeState.ALL,
+                                title = {
+                                    Text(item.title)
+                                },
+                                text = {
+                                    Text(item.text)
+                                },
+                                leading = {
+                                    Box(
+                                        modifier = Modifier.size(24.dp),
+                                    ) {
+                                        VaultItemIcon2(icon = item.icon)
+                                    }
+                                },
+                                trailing = {
+                                    ChevronIcon()
+                                },
+                                onClick = item.onClick,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        actions = {
+            val updatedOnDeny by rememberUpdatedState(state.onDeny)
+            TextButton(
+                enabled = updatedOnDeny != null,
+                onClick = {
+                    updatedOnDeny?.invoke()
+                },
+            ) {
+                Text(stringResource(Res.string.close))
+            }
+        },
+    )
+}

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerState.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerState.kt
@@ -1,0 +1,18 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import com.artemchep.keyguard.feature.auth.common.TextFieldModel
+import com.artemchep.keyguard.feature.home.vault.model.VaultItemIcon
+
+data class CipherLinkPickerState(
+    val query: TextFieldModel = TextFieldModel.empty,
+    val items: List<Item> = emptyList(),
+    val onDeny: (() -> Unit)? = null,
+) {
+    data class Item(
+        val id: String,
+        val title: String,
+        val text: String,
+        val icon: VaultItemIcon,
+        val onClick: () -> Unit,
+    )
+}

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkPickerStateProducer.kt
@@ -1,0 +1,130 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import androidx.compose.runtime.Composable
+import com.artemchep.keyguard.common.model.DSecret
+import com.artemchep.keyguard.common.model.titleH
+import com.artemchep.keyguard.common.usecase.GetAppIcons
+import com.artemchep.keyguard.common.usecase.GetCiphers
+import com.artemchep.keyguard.common.usecase.GetWebsiteIcons
+import com.artemchep.keyguard.feature.auth.common.TextFieldModel
+import com.artemchep.keyguard.feature.auth.common.textFieldHandle
+import com.artemchep.keyguard.feature.home.vault.screen.toVaultItemIcon
+import com.artemchep.keyguard.feature.navigation.RouteResultTransmitter
+import com.artemchep.keyguard.feature.navigation.state.navigatePopSelf
+import com.artemchep.keyguard.feature.navigation.state.produceScreenState
+import kotlinx.coroutines.flow.combine
+import org.kodein.di.compose.localDI
+import org.kodein.di.direct
+import org.kodein.di.instance
+
+@Composable
+fun produceCipherLinkPickerState(
+    args: CipherLinkPickerRoute.Args,
+    transmitter: RouteResultTransmitter<CipherLinkPickerResult>,
+): CipherLinkPickerState = with(localDI().direct) {
+    produceCipherLinkPickerState(
+        args = args,
+        transmitter = transmitter,
+        getCiphers = instance(),
+        getAppIcons = instance(),
+        getWebsiteIcons = instance(),
+    )
+}
+
+@Composable
+fun produceCipherLinkPickerState(
+    args: CipherLinkPickerRoute.Args,
+    transmitter: RouteResultTransmitter<CipherLinkPickerResult>,
+    getCiphers: GetCiphers,
+    getAppIcons: GetAppIcons,
+    getWebsiteIcons: GetWebsiteIcons,
+): CipherLinkPickerState = produceScreenState(
+    key = "cipher_link_picker",
+    initial = CipherLinkPickerState(),
+    args = arrayOf(args, getCiphers, getAppIcons, getWebsiteIcons),
+) {
+    val queryHandle = textFieldHandle(
+        key = "query",
+        initial = "",
+    )
+    val typeTitles = DSecret.Type.entries
+        .associateWith { type -> translate(type.titleH()) }
+
+    combine(
+        getCiphers(),
+        queryHandle.sink,
+        getAppIcons(),
+        getWebsiteIcons(),
+    ) { ciphers, queryCell, appIcons, websiteIcons ->
+        val query = queryCell.text.trim()
+        val items = filterCipherLinkPickerCiphers(
+            ciphers = ciphers,
+            accountId = args.accountId,
+            excludedCipherId = args.excludedCipherId,
+            query = query,
+        )
+            .asSequence()
+            .map { cipher ->
+                val link = requireNotNull(
+                    cipher.service.remote?.id?.let(CipherLink::of),
+                )
+                CipherLinkPickerState.Item(
+                    id = cipher.id,
+                    title = cipher.name,
+                    text = cipher.login?.username
+                        ?.takeIf { it.isNotBlank() }
+                        ?: typeTitles.getValue(cipher.type),
+                    icon = cipher.toVaultItemIcon(
+                        appIcons = appIcons,
+                        websiteIcons = websiteIcons,
+                    ),
+                    onClick = {
+                        transmitter(CipherLinkPickerResult.Confirm(link))
+                        navigatePopSelf()
+                    },
+                )
+            }
+            .toList()
+
+        CipherLinkPickerState(
+            query = TextFieldModel(
+                text = queryCell.text,
+                textRevision = queryCell.revision,
+                onChange = queryHandle::onChange,
+                onSetText = queryHandle::setText,
+            ),
+            items = items,
+            onDeny = {
+                transmitter(CipherLinkPickerResult.Deny)
+                navigatePopSelf()
+            },
+        )
+    }
+}
+
+internal fun filterCipherLinkPickerCiphers(
+    ciphers: List<DSecret>,
+    accountId: String,
+    excludedCipherId: String?,
+    query: String,
+): List<DSecret> = ciphers
+    .asSequence()
+    .filter { cipher ->
+        cipher.accountId == accountId &&
+                cipher.id != excludedCipherId &&
+                cipher.deletedDate == null &&
+                cipher.service.remote?.id?.let(CipherLink::of) != null
+    }
+    .filter { cipher ->
+        query.isBlank() || cipher.matchesCipherLinkPickerQuery(query.trim())
+    }
+    .sortedWith(
+        compareBy<DSecret> { it.name.lowercase() }
+            .thenBy { it.id },
+    )
+    .toList()
+
+private fun DSecret.matchesCipherLinkPickerQuery(query: String): Boolean =
+    name.contains(query, ignoreCase = true) ||
+            login?.username?.contains(query, ignoreCase = true) == true ||
+            uris.any { it.uri.contains(query, ignoreCase = true) }

--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/screen/VaultViewStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/home/vault/screen/VaultViewStateProducer.kt
@@ -194,7 +194,11 @@ import com.artemchep.keyguard.feature.home.vault.by
 import com.artemchep.keyguard.feature.home.vault.collections.CollectionsRoute
 import com.artemchep.keyguard.feature.home.vault.collections.CollectionsRouteFactory
 import com.artemchep.keyguard.feature.home.vault.component.UrlAppStoreListings
+import com.artemchep.keyguard.feature.home.vault.component.VaultItemIcon2
 import com.artemchep.keyguard.feature.home.vault.component.formatCardNumber
+import com.artemchep.keyguard.feature.home.vault.link.CipherRelation
+import com.artemchep.keyguard.feature.home.vault.link.CipherRelations
+import com.artemchep.keyguard.feature.home.vault.link.resolveCipherRelations
 import com.artemchep.keyguard.feature.home.vault.model.VaultViewItem
 import com.artemchep.keyguard.feature.home.vault.model.Visibility
 import com.artemchep.keyguard.feature.home.vault.model.transformShapes
@@ -276,6 +280,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -1519,6 +1524,7 @@ suspend fun RememberStateFlowScope.vaultViewScreenStateProducer(
                         executeCommand = executeCommand,
                         markdown = markdown,
                         concealFields = concealFields || secretOrNull.reprompt,
+                        appIcons = appIcons,
                         websiteIcons = websiteIcons,
                         getGravatarUrl = getGravatarUrl,
                         copy = copy,
@@ -1589,6 +1595,7 @@ private fun RememberStateFlowScope.oh(
     executeCommand: ExecuteCommand,
     markdown: Boolean,
     concealFields: Boolean,
+    appIcons: Boolean,
     websiteIcons: Boolean,
     getGravatarUrl: GetGravatarUrl,
     copy: CopyText,
@@ -1614,6 +1621,13 @@ private fun RememberStateFlowScope.oh(
     androidAppFDroidParser: AndroidAppFDroidParser,
     verify: ((() -> Unit) -> Unit)?,
 ) = flow<VaultViewItem> {
+    val cipherRelations = resolveCipherRelations(
+        cipher = cipher,
+        ciphers = ciphers,
+    )
+    val linkedFieldIndexes = cipherRelations.outgoing
+        .mapTo(mutableSetOf(), CipherRelation::fieldIndex)
+
     val hasWiFi = kotlin.run {
         val ssid = cipher.login?.username
             ?: cipher.fields
@@ -2687,8 +2701,10 @@ private fun RememberStateFlowScope.oh(
                 emit(item)
             }
     }
-    if (cipher.fields.isNotEmpty()) {
-        val sectionText = if (cipher.fields.size > 1) {
+    val regularFields = cipher.fields
+        .filterIndexed { index, _ -> index !in linkedFieldIndexes }
+    if (regularFields.isNotEmpty()) {
+        val sectionText = if (regularFields.size > 1) {
             translate(Res.string.custom_fields)
         } else translate(Res.string.custom_field)
         val section = VaultViewItem.Section(
@@ -2698,6 +2714,9 @@ private fun RememberStateFlowScope.oh(
         emit(section)
         // items
         cipher.fields.forEachIndexed { index, field ->
+            if (index in linkedFieldIndexes) {
+                return@forEachIndexed
+            }
             if (field.type == DSecret.Field.Type.Boolean) {
                 fun createAction(
                     value: Boolean,
@@ -2809,6 +2828,14 @@ private fun RememberStateFlowScope.oh(
             emit(m)
         }
     }
+    emitAll(
+        cipherRelationItems(
+            cipherRelations = cipherRelations,
+            vaultViewRouteFactory = vaultViewRouteFactory,
+            appIcons = appIcons,
+            websiteIcons = websiteIcons,
+        ),
+    )
     if (cipher.type != DSecret.Type.SecureNote && cipher.notes.isNotEmpty()) {
         val section = VaultViewItem.Section(
             id = "note",
@@ -3131,6 +3158,107 @@ private fun RememberStateFlowScope.oh(
                 .orEmpty(),
         )
         emit(remoteRevDate)
+    }
+}
+
+private fun RememberStateFlowScope.cipherRelationItems(
+    cipherRelations: CipherRelations,
+    vaultViewRouteFactory: VaultViewRouteFactory,
+    appIcons: Boolean,
+    websiteIcons: Boolean,
+) = flow<VaultViewItem> {
+    if (cipherRelations.outgoing.isNotEmpty()) {
+        emit(
+            VaultViewItem.Section(
+                id = "cipher_links.outgoing",
+                text = translate(Res.string.cipher_links_outgoing_title),
+            ),
+        )
+        cipherRelations.outgoing.forEach { relation ->
+            val target = relation.cipher
+            emit(
+                VaultViewItem.Action(
+                    id = "cipher_links.outgoing.${relation.fieldIndex}",
+                    title = relation.label.ifBlank {
+                        translate(Res.string.cipher_link_default_label)
+                    },
+                    text = target?.name
+                        ?: translate(Res.string.cipher_link_unavailable_title),
+                    leading = {
+                        if (target != null) {
+                            Box(
+                                modifier = Modifier.size(24.dp),
+                            ) {
+                                VaultItemIcon2(
+                                    icon = target.toVaultItemIcon(
+                                        appIcons = appIcons,
+                                        websiteIcons = websiteIcons,
+                                    ),
+                                )
+                            }
+                        } else {
+                            IconBox(main = Icons.Outlined.ErrorOutline)
+                        }
+                    },
+                    trailing = target?.let {
+                        {
+                            ChevronIcon()
+                        }
+                    },
+                    onClick = target?.let {
+                        {
+                            val route = vaultViewRouteFactory.create(
+                                itemId = target.id,
+                                accountId = target.accountId,
+                            )
+                            navigate(NavigationIntent.NavigateToRoute(route))
+                        }
+                    },
+                ),
+            )
+        }
+    }
+    if (cipherRelations.incoming.isNotEmpty()) {
+        emit(
+            VaultViewItem.Section(
+                id = "cipher_links.incoming",
+                text = translate(Res.string.cipher_links_incoming_title),
+            ),
+        )
+        cipherRelations.incoming.forEach { relation ->
+            val source = requireNotNull(relation.cipher)
+            emit(
+                VaultViewItem.Action(
+                    id = "cipher_links.incoming.${source.id}.${relation.fieldIndex}",
+                    title = relation.label.ifBlank {
+                        translate(Res.string.cipher_link_default_label)
+                    },
+                    text = source.name,
+                    leading = {
+                        Box(
+                            modifier = Modifier.size(24.dp),
+                        ) {
+                            VaultItemIcon2(
+                                icon = source.toVaultItemIcon(
+                                    appIcons = appIcons,
+                                    websiteIcons = websiteIcons,
+                                ),
+                            )
+                        }
+                    },
+                    trailing = {
+                        ChevronIcon()
+                    },
+                    onClick = {
+                        val route = vaultViewRouteFactory.create(
+                            itemId = source.id,
+                            accountId = source.accountId,
+                        )
+                        navigate(NavigationIntent.NavigateToRoute(route))
+                    },
+                ),
+            )
+        }
     }
 }
 

--- a/common/src/commonTest/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkTest.kt
+++ b/common/src/commonTest/kotlin/com/artemchep/keyguard/feature/home/vault/link/CipherLinkTest.kt
@@ -1,0 +1,222 @@
+package com.artemchep.keyguard.feature.home.vault.link
+
+import com.artemchep.keyguard.common.model.DSecret
+import com.artemchep.keyguard.core.store.bitwarden.BitwardenService
+import kotlin.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class CipherLinkTest {
+    @Test
+    fun `formats a canonical cipher link`() {
+        val link = requireNotNull(
+            CipherLink.of("A0Eebc99-9C0B-4EF8-BB6D-6BB9BD380A11"),
+        )
+
+        assertEquals(
+            "keyguard://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            link.toString(),
+        )
+    }
+
+    @Test
+    fun `parses a link with surrounding whitespace`() {
+        val link = CipherLink.parse(
+            "  keyguard://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n",
+        )
+
+        assertEquals(
+            "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            link?.remoteCipherId,
+        )
+    }
+
+    @Test
+    fun `rejects values outside the exact protocol`() {
+        assertNull(CipherLink.parse(null))
+        assertNull(CipherLink.parse("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"))
+        assertNull(CipherLink.parse("https://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"))
+        assertNull(CipherLink.parse("keyguard://item/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"))
+        assertNull(CipherLink.parse("keyguard://cipher/not-a-uuid"))
+        assertNull(CipherLink.parse("keyguard://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/extra"))
+        assertNull(CipherLink.parse("keyguard://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11?x=1"))
+        assertNull(CipherLink.parse("keyguard://cipher/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11#x"))
+    }
+
+    @Test
+    fun `resolves outgoing links and keeps missing targets`() {
+        val target = cipher(
+            localId = "target-local",
+            remoteId = TARGET_REMOTE_ID,
+            name = "Google account",
+        )
+        val current = cipher(
+            localId = "current-local",
+            remoteId = CURRENT_REMOTE_ID,
+            fields = listOf(
+                textField("Sign in with Google", TARGET_REMOTE_ID),
+                textField("Missing item", MISSING_REMOTE_ID),
+                DSecret.Field(
+                    name = "Hidden link",
+                    value = requireNotNull(CipherLink.of(TARGET_REMOTE_ID)).toString(),
+                    type = DSecret.Field.Type.Hidden,
+                ),
+                DSecret.Field(
+                    name = "Ordinary UUID",
+                    value = TARGET_REMOTE_ID,
+                    type = DSecret.Field.Type.Text,
+                ),
+            ),
+        )
+
+        val relations = resolveCipherRelations(current, listOf(current, target))
+
+        assertEquals(2, relations.outgoing.size)
+        assertSame(target, relations.outgoing[0].cipher)
+        assertNull(relations.outgoing[1].cipher)
+        assertEquals(listOf(0, 1), relations.outgoing.map { it.fieldIndex })
+    }
+
+    @Test
+    fun `derives backlinks only inside the same account`() {
+        val current = cipher(
+            localId = "current-local",
+            remoteId = CURRENT_REMOTE_ID,
+        )
+        val source = cipher(
+            localId = "source-local",
+            remoteId = SOURCE_REMOTE_ID,
+            fields = listOf(textField("Uses account", CURRENT_REMOTE_ID)),
+        )
+        val crossAccountSource = cipher(
+            localId = "cross-account-local",
+            remoteId = CROSS_ACCOUNT_REMOTE_ID,
+            accountId = "other-account",
+            fields = listOf(textField("Cross-account", CURRENT_REMOTE_ID)),
+        )
+        val deletedSource = cipher(
+            localId = "deleted-local",
+            remoteId = DELETED_REMOTE_ID,
+            fields = listOf(textField("Deleted", CURRENT_REMOTE_ID)),
+            deletedDate = NOW,
+        )
+
+        val relations = resolveCipherRelations(
+            current,
+            listOf(current, source, crossAccountSource, deletedSource),
+        )
+
+        assertEquals(1, relations.incoming.size)
+        assertSame(source, relations.incoming.single().cipher)
+        assertEquals("Uses account", relations.incoming.single().label)
+    }
+
+    @Test
+    fun `treats a self link as unavailable`() {
+        val current = cipher(
+            localId = "current-local",
+            remoteId = CURRENT_REMOTE_ID,
+            fields = listOf(textField("Self", CURRENT_REMOTE_ID)),
+        )
+
+        val relations = resolveCipherRelations(current, listOf(current))
+
+        assertEquals(1, relations.outgoing.size)
+        assertNull(relations.outgoing.single().cipher)
+        assertEquals(emptyList(), relations.incoming)
+    }
+
+    @Test
+    fun `picker filters by account lifecycle and remote id`() {
+        val selectable = cipher(
+            localId = "selectable",
+            remoteId = TARGET_REMOTE_ID,
+            name = "Google account",
+            username = "user@gmail.com",
+        )
+        val excluded = cipher(
+            localId = "excluded",
+            remoteId = SOURCE_REMOTE_ID,
+        )
+        val crossAccount = cipher(
+            localId = "cross-account",
+            remoteId = CROSS_ACCOUNT_REMOTE_ID,
+            accountId = "other-account",
+        )
+        val deleted = cipher(
+            localId = "deleted",
+            remoteId = DELETED_REMOTE_ID,
+            deletedDate = NOW,
+        )
+        val localOnly = cipher(
+            localId = "local-only",
+            remoteId = null,
+        )
+
+        val result = filterCipherLinkPickerCiphers(
+            ciphers = listOf(selectable, excluded, crossAccount, deleted, localOnly),
+            accountId = "account",
+            excludedCipherId = excluded.id,
+            query = "gmail",
+        )
+
+        assertEquals(listOf(selectable), result)
+    }
+
+    private fun textField(name: String, remoteId: String) = DSecret.Field(
+        name = name,
+        value = requireNotNull(CipherLink.of(remoteId)).toString(),
+        type = DSecret.Field.Type.Text,
+    )
+
+    private fun cipher(
+        localId: String,
+        remoteId: String?,
+        name: String = localId,
+        accountId: String = "account",
+        fields: List<DSecret.Field> = emptyList(),
+        deletedDate: Instant? = null,
+        username: String? = null,
+    ) = DSecret(
+        id = localId,
+        accountId = accountId,
+        folderId = null,
+        organizationId = null,
+        collectionIds = emptySet(),
+        revisionDate = NOW,
+        createdDate = NOW,
+        archivedDate = null,
+        deletedDate = deletedDate,
+        service = BitwardenService(
+            remote = remoteId?.let { id ->
+                BitwardenService.Remote(
+                    id = id,
+                    revisionDate = NOW,
+                    deletedDate = deletedDate,
+                )
+            },
+        ),
+        name = name,
+        notes = "",
+        favorite = false,
+        reprompt = false,
+        synced = true,
+        fields = fields,
+        type = DSecret.Type.Login,
+        login = DSecret.Login(
+            username = username,
+        ),
+    )
+
+    private companion object {
+        val NOW = Instant.fromEpochSeconds(1)
+        const val CURRENT_REMOTE_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        const val TARGET_REMOTE_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12"
+        const val MISSING_REMOTE_ID = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13"
+        const val SOURCE_REMOTE_ID = "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14"
+        const val CROSS_ACCOUNT_REMOTE_ID = "e0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15"
+        const val DELETED_REMOTE_ID = "f0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16"
+    }
+}


### PR DESCRIPTION
# Background:
> I am currently migrating from 1Password to Bitwarden. One feature I rely on in 1Password is the ability to link related vault items together—for example, signing with <account>, linking an account to its SSH key, paid cards, or other associated credentials. 
<img width="500" height="579" alt="image" src="https://github.com/user-attachments/assets/35d740c1-127a-47f0-8dc9-fc10923da802" />

Bitwarden does not currently provide an equivalent item-linking feature, which makes some of these relationships harder to preserve during migration. This change is intended to provide a lightweight way to represent and navigate links between related vault items, while keeping the existing Bitwarden data model and server compatibility intact.

# How it works
The links are stored using Text fields (non-concealed) and interpreted only by the client, so items remain accessible and editable in official Bitwarden clients ( Bitwarden-compatible ), even though the enhanced link UI is only available in Keyguard.

Item links are stored as regular, non-concealed text custom fields using the following URI format:
```
keyguard://cipher/<cipher-id>
```
Here, cipher-id is the UUID assigned to the vault item by the **remote** Bitwarden-compatible server. (remote ID makes the link stable across synchronization)

When viewing an item, Keyguard resolves these fields dynamically and displays:

  - Linked items for outgoing links created by the current item.
  - Referenced by for other items that link back to the current item.

Selecting a resolved link opens the related vault item. If its target is deleted, unavailable, or no longer belongs to the account, the original field is preserved and shown as Item unavailable instead of silently removing the reference.
<img width="500" height="158" alt="Screenshot_2026-07-19-00-19-17-78_bfa598d53dc622bb2af710039edac040" src="https://github.com/user-attachments/assets/b292a04e-adc3-43c3-9417-136bb964ff43" />

# How to use

1. Create or edit a item as usual.
2. Add a `Text` field ***( NOT concealed !)*** to item.
3. ~~Enter the URI link :D~~ Click the three-dot menu of the Text field, click `Link to an item`.
4. Select the item you want to link with.
5. Save changes and enjoy :)

# Pictures
<img width="400" height="314" alt="image" src="https://github.com/user-attachments/assets/b78cb450-4960-4c0c-9d34-8d5fc831f435" />
<img width="400" height="596" alt="IMG_20260719_023017" src="https://github.com/user-attachments/assets/ef9718c8-7d65-45f4-91f9-be2b186e45e3" />
<img width="400" height="191" alt="image" src="https://github.com/user-attachments/assets/1ca8a752-f3f2-4bbe-a8ae-8b8790aeacc0" />

