### PR TITLE
fix(Desktop): Declare the okhttp BOM in desktopApp

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(libs.kdroidfilter.composenativetray)
                 implementation(compose.desktop.currentOs)
                 implementation(libs.kotlin.stdlib)
+                implementation(project.dependencies.platform(libs.squareup.okhttp.bom))
                 implementation(libs.squareup.okhttp)
                 implementation(project(":util:crypto"))
                 implementation(project(":common"))


### PR DESCRIPTION
`:desktopApp` declares `implementation(libs.squareup.okhttp)`, but that catalog alias carries no version. It is meant to pick one up from the okhttp BOM, which is declared only in `:common`.

So the compile classpath takes its okhttp version from `ktor-client-okhttp`, which `:common` exports as `api` and which requires 5.3.2. The BOM does not help there, because `:common`'s `jvmMain` declares it as `implementation`; so the 5.4.0 constraint reaches `:desktopApp`'s runtime classpath but not its compile classpath. The desktop app therefore compiles against okhttp 5.3.2 and runs against 5.4.0. Both are 5.x, so nothing breaks today. The catch is that the compile version is decided by an unrelated library's transitive requirement rather than by `okHttp = "5.4.0"` in the catalog, so a ktor bump can move it silently.

Android is unaffected. `:common` exports okhttp to Android consumers and exports the BOM alongside it, so `:androidApp` never declares either. On the desktop side `:common` keeps okhttp internal and `:desktopApp` declares it itself, which is where the BOM belongs too.