### PR TITLE
feat(windows): add Windows Hello unlock

### DIFF
--- a/common/src/desktopMain/kotlin/com/artemchep/keyguard/core/session/FingerprintRepositoryModule.kt
+++ b/common/src/desktopMain/kotlin/com/artemchep/keyguard/core/session/FingerprintRepositoryModule.kt
@@ -131,9 +131,14 @@ class BiometricStatusUseCaseImpl(
     )
 
     override fun invoke(): Flow<BiometricStatus> = flow {
-        // FIXME: Properly load native library on Flatpak platform
-        //  instead of just assuming that only MacOS supports biometrics.
-        val hasBiometrics = CurrentPlatform is Platform.Desktop.MacOS && hasBiometrics()
+        // Native biometric verification is currently implemented on macOS and Windows.
+        val hasBiometrics = when (CurrentPlatform) {
+            is Platform.Desktop.MacOS,
+            is Platform.Desktop.Windows,
+            -> hasBiometrics()
+
+            else -> false
+        }
         val event = if (hasBiometrics) {
             BiometricStatus.Available(
                 createCipher = { purpose ->

--- a/common/src/desktopMain/kotlin/com/artemchep/keyguard/feature/biometric/BiometricPromptEffect.kt
+++ b/common/src/desktopMain/kotlin/com/artemchep/keyguard/feature/biometric/BiometricPromptEffect.kt
@@ -9,6 +9,7 @@ import arrow.core.left
 import arrow.core.right
 import com.artemchep.autotype.biometricsVerify
 import com.artemchep.keyguard.common.model.BiometricAuthException
+import com.artemchep.keyguard.common.model.BiometricAuthException.Companion.ERROR_CANCELED
 import com.artemchep.keyguard.common.model.BiometricAuthException.Companion.ERROR_UNKNOWN
 import com.artemchep.keyguard.common.model.BiometricAuthPrompt
 import com.artemchep.keyguard.common.model.BiometricAuthPromptSimple
@@ -45,8 +46,7 @@ actual fun BiometricPromptEffect(flow: Flow<PureBiometricAuthPrompt>) {
                             event.onComplete(result)
                         },
                         onFailure = {
-                            val message = it.message.orEmpty()
-                            val result = BiometricAuthException(ERROR_UNKNOWN, message)
+                            val result = it.toBiometricAuthException()
                                 .left()
                             event.onComplete(result)
                         },
@@ -65,8 +65,7 @@ actual fun BiometricPromptEffect(flow: Flow<PureBiometricAuthPrompt>) {
                             event.onComplete(result)
                         },
                         onFailure = {
-                            val message = it.message.orEmpty()
-                            val result = BiometricAuthException(ERROR_UNKNOWN, message)
+                            val result = it.toBiometricAuthException()
                                 .left()
                             event.onComplete(result)
                         },
@@ -75,4 +74,19 @@ actual fun BiometricPromptEffect(flow: Flow<PureBiometricAuthPrompt>) {
             }
         }
     }
+}
+
+private val backgroundWindowErrors = setOf(
+    "Keyguard does not have a foreground window",
+    "Keyguard is not the foreground application",
+)
+
+internal fun Throwable.toBiometricAuthException(): BiometricAuthException {
+    val message = message.orEmpty()
+    val code = if (message in backgroundWindowErrors) {
+        ERROR_CANCELED
+    } else {
+        ERROR_UNKNOWN
+    }
+    return BiometricAuthException(code, message)
 }

--- a/common/src/desktopTest/kotlin/com/artemchep/keyguard/feature/biometric/BiometricPromptEffectTest.kt
+++ b/common/src/desktopTest/kotlin/com/artemchep/keyguard/feature/biometric/BiometricPromptEffectTest.kt
@@ -1,0 +1,22 @@
+package com.artemchep.keyguard.feature.biometric
+
+import com.artemchep.keyguard.common.model.BiometricAuthException.Companion.ERROR_CANCELED
+import com.artemchep.keyguard.common.model.BiometricAuthException.Companion.ERROR_UNKNOWN
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BiometricPromptEffectTest {
+    @Test
+    fun `background window rejection is treated as cancellation`() {
+        val error = IllegalStateException("Keyguard is not the foreground application")
+
+        assertEquals(ERROR_CANCELED, error.toBiometricAuthException().code)
+    }
+
+    @Test
+    fun `unexpected native failure remains an error`() {
+        val error = IllegalStateException("native failure")
+
+        assertEquals(ERROR_UNKNOWN, error.toBiometricAuthException().code)
+    }
+}

--- a/desktopLibNative/src/Cargo.lock
+++ b/desktopLibNative/src/Cargo.lock
@@ -24,6 +24,8 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "libc",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -33,7 +35,152 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]

--- a/desktopLibNative/src/Cargo.toml
+++ b/desktopLibNative/src/Cargo.toml
@@ -15,6 +15,17 @@ crate-type = ["cdylib"]
 [dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = [
+    "Foundation",
+    "Security_Credentials_UI",
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_WinRT",
+    "Win32_UI_WindowsAndMessaging",
+] }
+windows-future = "0.3.2"
+
 [build-dependencies]
 cc = "1"
 

--- a/desktopLibNative/src/src/biometrics.rs
+++ b/desktopLibNative/src/src/biometrics.rs
@@ -2,7 +2,11 @@ use crate::ffi::BiometricsVerifyCallback;
 use std::ffi::c_char;
 
 #[cfg_attr(target_os = "macos", path = "biometrics/macos.rs")]
-#[cfg_attr(not(target_os = "macos"), path = "biometrics/stub.rs")]
+#[cfg_attr(target_os = "windows", path = "biometrics/windows.rs")]
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "windows")),
+    path = "biometrics/stub.rs"
+)]
 mod imp;
 
 pub(crate) fn is_supported() -> bool {

--- a/desktopLibNative/src/src/biometrics/windows.rs
+++ b/desktopLibNative/src/src/biometrics/windows.rs
@@ -1,0 +1,158 @@
+use crate::ffi::{require_string, BiometricsVerifyCallback};
+use std::ffi::{c_char, CString};
+use windows::core::{factory, HSTRING};
+use windows::Security::Credentials::UI::{
+    UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
+};
+use windows::Win32::Foundation::{HWND, RPC_E_CHANGED_MODE};
+use windows::Win32::System::Threading::GetCurrentProcessId;
+use windows::Win32::System::WinRT::{
+    IUserConsentVerifierInterop, RoInitialize, RoUninitialize, RO_INIT_MULTITHREADED,
+};
+use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
+use windows_future::IAsyncOperation;
+
+pub(crate) fn is_supported() -> bool {
+    check_availability()
+        .map(|availability| availability == UserConsentVerifierAvailability::Available)
+        .unwrap_or(false)
+}
+
+pub(crate) fn verify(title: *const c_char, callback: BiometricsVerifyCallback) {
+    let Some(callback) = callback else {
+        return;
+    };
+
+    let result = require_string(title, "title").and_then(request_verification);
+    match result {
+        Ok(()) => {
+            // SAFETY: The non-null callback came from the exported C ABI and is
+            // invoked synchronously with the declared arguments. A null error
+            // pointer is the documented success representation.
+            unsafe { callback(true, std::ptr::null()) }
+        }
+        Err(message) => callback_failure(callback, message),
+    }
+}
+
+fn check_availability() -> Result<UserConsentVerifierAvailability, String> {
+    let _apartment = initialize_winrt()?;
+    UserConsentVerifier::CheckAvailabilityAsync()
+        .and_then(|operation| operation.join())
+        .map_err(|error| error.to_string())
+}
+
+fn request_verification(title: String) -> Result<(), String> {
+    let _apartment = initialize_winrt()?;
+    let hwnd = foreground_window_for_current_process()?;
+    let interop = factory::<UserConsentVerifier, IUserConsentVerifierInterop>()
+        .map_err(|error| error.to_string())?;
+    // SAFETY: `hwnd` is non-null and was verified to belong to this process;
+    // `interop` and the HSTRING remain alive until the call returns its async
+    // operation object.
+    let operation: IAsyncOperation<UserConsentVerificationResult> =
+        unsafe { interop.RequestVerificationForWindowAsync(hwnd, &HSTRING::from(title)) }
+            .map_err(|error| error.to_string())?;
+    let result = operation.join().map_err(|error| error.to_string())?;
+    if result == UserConsentVerificationResult::Verified {
+        Ok(())
+    } else {
+        Err(format!(
+            "Windows Hello verification did not succeed: {result:?}"
+        ))
+    }
+}
+
+struct WinRtApartment {
+    uninitialize: bool,
+}
+
+impl Drop for WinRtApartment {
+    fn drop(&mut self) {
+        if self.uninitialize {
+            // SAFETY: This guard calls RoUninitialize exactly once only when
+            // the matching RoInitialize invocation succeeded on this thread.
+            unsafe {
+                RoUninitialize();
+            }
+        }
+    }
+}
+
+fn initialize_winrt() -> Result<WinRtApartment, String> {
+    // SAFETY: RoInitialize is called on the current thread and balanced by the
+    // guard below when it succeeds. RPC_E_CHANGED_MODE means another valid
+    // apartment already owns this thread and must not be uninitialized here.
+    match unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
+        Ok(()) => Ok(WinRtApartment { uninitialize: true }),
+        Err(error) if error.code() == RPC_E_CHANGED_MODE => Ok(WinRtApartment {
+            uninitialize: false,
+        }),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn foreground_window_for_current_process() -> Result<HWND, String> {
+    // SAFETY: GetForegroundWindow takes no pointers and returns a borrowed HWND
+    // that is checked for null before any use.
+    let hwnd = unsafe { GetForegroundWindow() };
+    if hwnd.0.is_null() {
+        return Err("Keyguard does not have a foreground window".to_owned());
+    }
+
+    let mut owner_process_id = 0_u32;
+    // SAFETY: `hwnd` is non-null and the output pointer refers to a live local
+    // u32 for the duration of the call.
+    unsafe {
+        GetWindowThreadProcessId(hwnd, Some(&mut owner_process_id));
+    }
+    // SAFETY: GetCurrentProcessId takes no arguments and has no preconditions.
+    let current_process_id = unsafe { GetCurrentProcessId() };
+    if owner_process_id != current_process_id {
+        return Err("Keyguard is not the foreground application".to_owned());
+    }
+
+    Ok(hwnd)
+}
+
+fn callback_failure(callback: unsafe extern "C" fn(bool, *const c_char), message: String) {
+    let message = CString::new(message)
+        .unwrap_or_else(|_| CString::new("Windows Hello verification failed").unwrap());
+    // SAFETY: The callback came from the exported C ABI, and `message` remains
+    // alive and NUL-terminated for the entire synchronous invocation.
+    unsafe {
+        callback(false, message.as_ptr());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{callback_failure, check_availability};
+    use std::ffi::{c_char, CStr};
+    use std::sync::Mutex;
+
+    static MESSAGE: Mutex<Option<String>> = Mutex::new(None);
+
+    unsafe extern "C" fn record_failure(success: bool, error: *const c_char) {
+        assert!(!success);
+        assert!(!error.is_null());
+        // SAFETY: The production callback supplies a non-null, NUL-terminated
+        // CString which stays alive for this synchronous callback.
+        let message = unsafe { CStr::from_ptr(error) }
+            .to_string_lossy()
+            .into_owned();
+        *MESSAGE.lock().unwrap() = Some(message);
+    }
+
+    #[test]
+    fn windows_hello_availability_query_completes() {
+        let result = check_availability();
+        assert!(result.is_ok(), "availability query failed: {result:?}");
+    }
+
+    #[test]
+    fn failure_callback_receives_an_error_message() {
+        callback_failure(record_failure, "not verified".to_owned());
+        assert_eq!(MESSAGE.lock().unwrap().as_deref(), Some("not verified"));
+    }
+}

--- a/desktopLibNative/src/src/ffi.rs
+++ b/desktopLibNative/src/src/ffi.rs
@@ -101,12 +101,22 @@ mod tests {
     }
 
     #[test]
-    fn free_ptr_releases_strdup_allocation() {
+    fn free_ptr_releases_c_allocation() {
         let payload = CString::new("hello").unwrap();
-        // SAFETY: CString provides a valid NUL-terminated source pointer for
-        // the duration of the call; strdup returns a C-allocator allocation.
-        let duplicated = unsafe { libc::strdup(payload.as_ptr()) };
+        let bytes = payload.as_bytes_with_nul();
+        // SAFETY: malloc receives the exact positive byte count needed for the
+        // CString, and the returned pointer is checked before it is written.
+        let duplicated = unsafe { libc::malloc(bytes.len()) }.cast::<std::ffi::c_char>();
         assert!(!duplicated.is_null());
+        // SAFETY: `duplicated` points to a writable allocation of `bytes.len()`
+        // bytes, while the CString source remains readable for the whole copy.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr().cast::<std::ffi::c_char>(),
+                duplicated,
+                bytes.len(),
+            );
+        }
 
         free_ptr(duplicated.cast());
     }

--- a/desktopLibNative/src/src/keychain.rs
+++ b/desktopLibNative/src/src/keychain.rs
@@ -1,7 +1,11 @@
 use std::ffi::c_char;
 
 #[cfg_attr(target_os = "macos", path = "keychain/macos.rs")]
-#[cfg_attr(not(target_os = "macos"), path = "keychain/stub.rs")]
+#[cfg_attr(target_os = "windows", path = "keychain/windows.rs")]
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "windows")),
+    path = "keychain/stub.rs"
+)]
 mod imp;
 
 pub(crate) fn add_password(id: *const c_char, password: *const c_char) -> bool {

--- a/desktopLibNative/src/src/keychain/windows.rs
+++ b/desktopLibNative/src/src/keychain/windows.rs
@@ -1,0 +1,257 @@
+use crate::ffi::require_string;
+use std::ffi::{c_char, c_void};
+use std::ptr;
+
+type Bool = i32;
+type Dword = u32;
+
+const CRED_TYPE_GENERIC: Dword = 1;
+const CRED_PERSIST_LOCAL_MACHINE: Dword = 2;
+const TARGET_PREFIX: &str = "com.artemchep.keyguard/";
+const USER_NAME: &str = "com.artemchep.keyguard";
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct FileTime {
+    low_date_time: Dword,
+    high_date_time: Dword,
+}
+
+#[repr(C)]
+struct CredentialW {
+    flags: Dword,
+    credential_type: Dword,
+    target_name: *mut u16,
+    comment: *mut u16,
+    last_written: FileTime,
+    credential_blob_size: Dword,
+    credential_blob: *mut u8,
+    persist: Dword,
+    attribute_count: Dword,
+    attributes: *mut c_void,
+    target_alias: *mut u16,
+    user_name: *mut u16,
+}
+
+#[link(name = "Advapi32")]
+unsafe extern "system" {
+    fn CredWriteW(credential: *const CredentialW, flags: Dword) -> Bool;
+    fn CredReadW(
+        target_name: *const u16,
+        credential_type: Dword,
+        flags: Dword,
+        credential: *mut *mut CredentialW,
+    ) -> Bool;
+    fn CredDeleteW(target_name: *const u16, credential_type: Dword, flags: Dword) -> Bool;
+    fn CredFree(buffer: *const c_void);
+}
+
+pub(crate) fn add_password(id: *const c_char, password: *const c_char) -> bool {
+    let Ok(id) = require_string(id, "id") else {
+        return false;
+    };
+    let Ok(password) = require_string(password, "password") else {
+        return false;
+    };
+    let mut target = wide(&target_name(&id));
+    let mut user_name = wide(USER_NAME);
+    let mut blob = password.into_bytes();
+    let credential = CredentialW {
+        flags: 0,
+        credential_type: CRED_TYPE_GENERIC,
+        target_name: target.as_mut_ptr(),
+        comment: ptr::null_mut(),
+        last_written: FileTime::default(),
+        credential_blob_size: blob.len() as Dword,
+        credential_blob: blob.as_mut_ptr(),
+        persist: CRED_PERSIST_LOCAL_MACHINE,
+        attribute_count: 0,
+        attributes: ptr::null_mut(),
+        target_alias: ptr::null_mut(),
+        user_name: user_name.as_mut_ptr(),
+    };
+
+    // SAFETY: Every pointer in `credential` either targets a live contiguous
+    // buffer for the duration of the call or is explicitly null as permitted
+    // by CREDENTIALW. Sizes exactly match the supplied byte buffers.
+    let success = unsafe { CredWriteW(&credential, 0) != 0 };
+    blob.fill(0);
+    success
+}
+
+pub(crate) fn get_password(id: *const c_char) -> *mut c_char {
+    let Ok(id) = require_string(id, "id") else {
+        return ptr::null_mut();
+    };
+    let target = wide(&target_name(&id));
+    let Some((credential, mut value)) = read_password(&target) else {
+        return ptr::null_mut();
+    };
+
+    let result = duplicate_for_ffi(&value).unwrap_or(ptr::null_mut());
+    value.fill(0);
+    wipe_and_free_credential(credential);
+    result
+}
+
+pub(crate) fn delete_password(id: *const c_char) -> bool {
+    let Ok(id) = require_string(id, "id") else {
+        return false;
+    };
+    let target = wide(&target_name(&id));
+    // SAFETY: `target` is NUL-terminated and remains alive for this call; the
+    // credential type and flags follow the Win32 contract.
+    unsafe { CredDeleteW(target.as_ptr(), CRED_TYPE_GENERIC, 0) != 0 }
+}
+
+pub(crate) fn contains_password(id: *const c_char) -> bool {
+    let Ok(id) = require_string(id, "id") else {
+        return false;
+    };
+    let target = wide(&target_name(&id));
+    let Some((credential, mut value)) = read_password(&target) else {
+        return false;
+    };
+    value.fill(0);
+    wipe_and_free_credential(credential);
+    true
+}
+
+fn read_password(target: &[u16]) -> Option<(*mut CredentialW, Vec<u8>)> {
+    let mut credential = ptr::null_mut();
+    // SAFETY: `target` is a live NUL-terminated UTF-16 slice and `credential`
+    // is a valid out pointer. A successful allocation is later freed by caller.
+    let success = unsafe { CredReadW(target.as_ptr(), CRED_TYPE_GENERIC, 0, &mut credential) != 0 };
+    if !success || credential.is_null() {
+        return None;
+    }
+
+    // SAFETY: `credential` is non-null and came from a successful CredReadW,
+    // so its fields are readable until the matching CredFree below or in caller.
+    let (blob_pointer, blob_size) = unsafe {
+        (
+            (*credential).credential_blob,
+            (*credential).credential_blob_size as usize,
+        )
+    };
+    if blob_size > 0 && blob_pointer.is_null() {
+        wipe_and_free_credential(credential);
+        return None;
+    }
+    let blob = if blob_size == 0 {
+        Vec::new()
+    } else {
+        // SAFETY: CredReadW supplied a non-null blob readable for `blob_size`
+        // bytes until the credential is freed.
+        unsafe { std::slice::from_raw_parts(blob_pointer, blob_size).to_vec() }
+    };
+    Some((credential, blob))
+}
+
+fn wipe_and_free_credential(credential: *mut CredentialW) {
+    if credential.is_null() {
+        return;
+    }
+    // SAFETY: `credential` must be a still-owned CredReadW result. Its blob is
+    // writable for the declared size until CredFree, which is called once here.
+    unsafe {
+        if !(*credential).credential_blob.is_null() {
+            ptr::write_bytes(
+                (*credential).credential_blob,
+                0,
+                (*credential).credential_blob_size as usize,
+            );
+        }
+        CredFree(credential.cast());
+    }
+}
+
+fn target_name(id: &str) -> String {
+    format!("{TARGET_PREFIX}{id}")
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+fn duplicate_for_ffi(value: &[u8]) -> Option<*mut c_char> {
+    let allocation_size = value.len().checked_add(1)?;
+    // SAFETY: malloc receives the exact positive byte count needed for this
+    // byte slice plus NUL terminator, and its result is checked before use.
+    let allocation = unsafe { libc::malloc(allocation_size) }.cast::<c_char>();
+    if allocation.is_null() {
+        return None;
+    }
+    // SAFETY: `allocation` is writable for `allocation_size` bytes, the source
+    // remains readable for the copy, and the final byte is in bounds.
+    unsafe {
+        ptr::copy_nonoverlapping(value.as_ptr().cast::<c_char>(), allocation, value.len());
+        *allocation.add(value.len()) = 0;
+    }
+    Some(allocation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        add_password, contains_password, delete_password, duplicate_for_ffi, get_password,
+        target_name, wide,
+    };
+    use std::ffi::{CStr, CString};
+
+    #[test]
+    fn target_is_namespaced_to_keyguard() {
+        assert_eq!(
+            target_name("biometric_unlock"),
+            "com.artemchep.keyguard/biometric_unlock"
+        );
+    }
+
+    #[test]
+    fn wide_strings_are_null_terminated() {
+        assert_eq!(wide("hello"), vec![104, 101, 108, 108, 111, 0]);
+    }
+
+    #[test]
+    fn ffi_string_uses_the_c_allocator() {
+        let pointer = duplicate_for_ffi(b"hello").unwrap();
+        // SAFETY: duplicate_for_ffi returned a non-null NUL-terminated copy.
+        let actual = unsafe { CStr::from_ptr(pointer) }.to_str().unwrap();
+        assert_eq!(actual, "hello");
+        // SAFETY: The pointer was allocated by libc::malloc and is freed once.
+        unsafe {
+            libc::free(pointer.cast());
+        }
+    }
+
+    #[test]
+    fn credential_manager_round_trip() {
+        let id = CString::new("keyguard_windows_test").unwrap();
+        let password = CString::new("temporary-test-value").unwrap();
+
+        let added = add_password(id.as_ptr(), password.as_ptr());
+        let contained = contains_password(id.as_ptr());
+        let actual_pointer = get_password(id.as_ptr());
+        let actual = if actual_pointer.is_null() {
+            None
+        } else {
+            // SAFETY: get_password returns either null or a NUL-terminated C
+            // allocation owned by the caller.
+            let value = unsafe { CStr::from_ptr(actual_pointer) }
+                .to_string_lossy()
+                .into_owned();
+            // SAFETY: The pointer was allocated by libc::malloc and is freed once.
+            unsafe {
+                libc::free(actual_pointer.cast());
+            }
+            Some(value)
+        };
+        let deleted = delete_password(id.as_ptr());
+
+        assert!(added);
+        assert!(contained);
+        assert_eq!(actual.as_deref(), Some("temporary-test-value"));
+        assert!(deleted);
+        assert!(!contains_password(id.as_ptr()));
+    }
+}


### PR DESCRIPTION
## Summary

- enable desktop biometric unlock on Windows when Windows Hello is available
- invoke `UserConsentVerifier` through the desktop HWND interop so consent is owned by the foreground Keyguard window
- store the biometric unlock key in Windows Credential Manager and wipe temporary credential buffers
- retain the existing macOS path and unsupported-platform stubs

Fixes #413.

## Validation

- `cargo fmt --manifest-path desktopLibNative/src/Cargo.toml -- --check`
- `cargo test --manifest-path desktopLibNative/src/Cargo.toml -- --test-threads=1` (35 passed on Windows 11, including Windows Hello availability and Credential Manager round-trip/delete)
- `cargo clippy --manifest-path desktopLibNative/src/Cargo.toml --all-targets -- -D warnings`
- `./gradlew.bat --no-daemon --max-workers=4 -Dkotlin.compiler.execution.strategy=in-process :desktopApp:packageReleaseMsi --stacktrace`