### PR TITLE
fix(auth): allow editing server during re-login

### DIFF
--- a/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/auth/AccountViewStateProducer.kt
+++ b/common/src/commonMain/kotlin/com/artemchep/keyguard/feature/auth/AccountViewStateProducer.kt
@@ -296,7 +296,10 @@ suspend fun RememberStateFlowScope.accountStateProducer(
                     email = email,
                     emailEditable = false,
                     env = env,
-                    envEditable = false,
+                    // A self-hosted server can move or change ports while the
+                    // account is offline. Let re-login repair the endpoint
+                    // without requiring a destructive sign-out first.
+                    envEditable = true,
                 ),
             ),
         ) {


### PR DESCRIPTION
## Summary
- allow the server/environment field to be edited during account re-login
- keep the account and local data in place while repairing a changed self-hosted endpoint

## Why
A self-hosted server can move or change ports while an account is offline. Previously the re-login flow locked the server field, forcing users toward signing out and re-adding the account even when only the endpoint needed correction.

## Test
- verified the common and desktop source sets compile as part of `:common:desktopTest`